### PR TITLE
fix authorization errors; they were backwards, saying the user had al…

### DIFF
--- a/THGLocation/LocationService.swift
+++ b/THGLocation/LocationService.swift
@@ -218,11 +218,11 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             requestAuth = true
         case .AuthorizedAlways:
             if authorization != .Always {
-                return NSError(THGLocationError.AuthorizationWhenInUse)
+                return NSError(THGLocationError.AuthorizationAlways)
             }
         case .AuthorizedWhenInUse:
             if authorization != .WhenInUse {
-                return NSError(THGLocationError.AuthorizationAlways)
+                return NSError(THGLocationError.AuthorizationWhenInUse)
             }
         }
         


### PR DESCRIPTION
…ready authorized 'always' when actually it was 'when in use' and vice versa
