### PR TITLE
Allow user to choose callback frequency and add coarser location monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ It is also possible to limit the callback frequency using the `updateFrequency` 
 let request = LocationUpdateRequest(accuracy: .Good, updateFrequency: .ChangesOnly, ...)
 ```
 
-Combining `accuracy: .Coarse` with `updateFrequency: .ChangesOnly` yields the lowest battery usage, at the expense of less accurate location data.
+Combining `accuracy: .Coarse` with `updateFrequency: .ChangesOnly`, along with `requestAuthorization(.Always)` yields the lowest battery usage, at the expense of less accurate location data and infrequent updates.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -42,25 +42,33 @@ func startLocationUpdates() {
     let request = LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in
         if success {
             if let actualLocation = location {
-                println("LISTENER 1: success! location is (\(actualLocation.coordinate.latitude), \(actualLocation.coordinate.longitude))")
+                print("LISTENER 1: success! location is (\(actualLocation.coordinate.latitude), \(actualLocation.coordinate.longitude))")
             }
         } else {
             if let theError = error {
-                println("LISTENER 1: error is \(theError.localizedDescription)")
+                print("LISTENER 1: error is \(theError.localizedDescription)")
             }
         }
     }
     
     // Register the listener
     if let addListenerError = LocationUpdateService().registerListener(self, request: request) {
-        println("LISTENER 1: error in adding the listener. error is \(addListenerError.localizedDescription)")
+        print("LISTENER 1: error in adding the listener. error is \(addListenerError.localizedDescription)")
     } else {
-        println("LISTENER 1 ADDED")
+        print("LISTENER 1 ADDED")
     }
 }
 ```
 
 Note that there can be an error in setting up the request and that is returned right away rather than in the handler block. You should check for that.
+
+It is also possible to limit the callback frequency using the `updateFrequency` parameter of `LocationUpdateRequest` like so:
+
+```Swift
+let request = LocationUpdateRequest(accuracy: .Good, updateFrequency: .ChangesOnly, ...)
+```
+
+Combining `accuracy: .Coarse` with `updateFrequency: .ChangesOnly` yields the lowest battery usage, at the expense of less accurate location data.
 
 ## Contributions
 

--- a/THGLocation/LocationService.swift
+++ b/THGLocation/LocationService.swift
@@ -46,7 +46,7 @@ More time and power is used going down this list as the system tries to provide 
 so be conservative according to your needs. `Good` should work well for most cases.
 */
 public enum LocationAccuracy: Int {
-    case Coarse = 0
+    case Coarse
     case Good
     case Better
     case Best
@@ -284,10 +284,10 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     
     // MARK: Internal Interface
     private func startMonitoringLocation() {
-        if self.shouldUseSignificantUpdateService() {
-            self.manager.startMonitoringSignificantLocationChanges()
+        if shouldUseSignificantUpdateService() {
+            manager.startMonitoringSignificantLocationChanges()
         } else {
-            self.manager.startUpdatingLocation()
+            manager.startUpdatingLocation()
         }
     }
     
@@ -295,11 +295,13 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
      * There are two kinds of location monitoring in iOS: significant updates and standard location monitoring.
      * Significant updates rely entirely on cell towers and therefore have low accuracy and low power consumption.
      * They also fire infrequently. If the user has requested location accuracy higher than .Coarse or wants
-     * continuous updates, the significant location service is inappropriate to use. Otherwise, it is a better option.
+     * continuous updates, the significant location service is inappropriate to use. Finally, the user must have
+     * requested .Always authorization status
      */
     private func shouldUseSignificantUpdateService() -> Bool {
         let hasContinuousListeners = allLocationListeners.filter({$0.request.updateFrequency == .Continuous}).count > 0
-        return !(hasContinuousListeners || accuracy.rawValue > LocationAccuracy.Coarse.rawValue)
+        let isAccuracyCoarseEnough = accuracy.rawValue <= LocationAccuracy.Coarse.rawValue
+        return !hasContinuousListeners && isAccuracyCoarseEnough && authorization == .Always
     }
 
     private func checkIfLocationServicesEnabled() -> NSError? {


### PR DESCRIPTION
This pull request does the following:
- Adds an `updateFrequency` parameter to `LocationUpdateRequest`. This parameter allows the user to choose if they want `.Continuous`, periodic requests or to get updated about `.ChangesOnly`.
- Adds `.Coarse` granularity to location accuracy

When `.ChangesOnly` is used in conjunction with `.Coarse` accuracy along with `.Always` authorization, Apple's significant-changes location service is used, which provides low-power infrequent location updates. See: https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocationManager_Class/index.html#//apple_ref/occ/instm/CLLocationManager/startMonitoringSignificantLocationChanges
