### PR TITLE
Fix crash when initializing without any listeners

### DIFF
--- a/THGLocation.xcodeproj/project.pbxproj
+++ b/THGLocation.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		2280E1751ABB4C380026F13A /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2280E1741ABB4C380026F13A /* LocationService.swift */; };
 		2280E17E1ABB4D4B0026F13A /* THGLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2280E0EA1ABB47860026F13A /* THGLocation.framework */; };
 		2280E17F1ABB4D4B0026F13A /* THGLocation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2280E0EA1ABB47860026F13A /* THGLocation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		46FBD85B1C232F7B0000E733 /* THGFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 220E9E981B8BDFB4000863F6 /* THGFoundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +125,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				46FBD85B1C232F7B0000E733 /* THGFoundation.framework in Frameworks */,
 				2280E0F61ABB47860026F13A /* THGLocation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/THGLocation/LocationService.swift
+++ b/THGLocation/LocationService.swift
@@ -346,7 +346,11 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         })
         
         // Find the max in the mapped array
-        if let locationAccuracy = LocationAccuracy(rawValue: accuracyRawValues.maxElement()!) {
+        guard let maxAccuracy = accuracyRawValues.maxElement() else {
+            return
+        }
+        
+        if let locationAccuracy = LocationAccuracy(rawValue: maxAccuracy) {
             computedAccuracy = locationAccuracy
         }
         

--- a/THGLocationTests/THGLocationTests.swift
+++ b/THGLocationTests/THGLocationTests.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 import XCTest
+import CoreLocation
+@testable import THGLocation
 
 class THGLocationTests: XCTestCase {
     
@@ -21,16 +23,11 @@ class THGLocationTests: XCTestCase {
         super.tearDown()
     }
     
-    func testExample() {
-        // This is an example of a functional test case.
-        XCTAssert(true, "Pass")
+    func testCalculateAndUpdateAccuracyCrash() {
+        LocationAuthorizationService().requestAuthorization(.WhenInUse)
+        LocationAuthorizationService().requestAuthorization(.Always)
+        
+        // no crash here is a test success
+        LocationManager.shared.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: 42, longitude: 42)])
     }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock() {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
 }


### PR DESCRIPTION
`cleanupLocationListeners` gets called from the CLLocationManager delegate function `didUpdateLocations`, which in turn calls `calculateAndUpdateAccuracy`. When no listeners are registered, there is no `maxElement`, and the force-unwrap crashes the program.
