### PR TITLE
Fix bug where authorization state can be incorrect if requesting auth…

### DIFF
--- a/THGLocation/LocationService.swift
+++ b/THGLocation/LocationService.swift
@@ -255,6 +255,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         
         let authStatus = CLLocationManager.authorizationStatus()
         var requestAuth = false
+        self.authorization = authorization
         switch authStatus {
         case .Denied, .Restricted:
             return NSError(THGLocationError.AuthorizationDeniedOrRestricted)
@@ -271,7 +272,6 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         }
         
         if requestAuth {
-            self.authorization = authorization
             switch self.authorization {
             case .Always:
                 manager.requestAlwaysAuthorization()


### PR DESCRIPTION
… is not required

Camelot defaults to `WhenInUse` authorization on initialization. If a user requests `Always` authorization via `requestAuthorization`, the first time things will work as expected - the user will be prompted if they would like to enable always authorization, they say yes, and all is well. However, the next time, the user is already authorized for `Always` and we do not need to request auth, but the `self.authorization` variable remains `WhenInUse`, which is inaccurate. This PR fixes that.
