### PR TITLE
Set distance filter with desired accuracy

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -177,7 +177,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     
     // MARK: Properties, initializers and internal structures
     
-    private var manager: CLLocationManager
+    var manager: CLLocationManager
     private var allLocationListeners: [LocationListener]
     private var accuracy: LocationAccuracy
     private var authorization: LocationAuthorization
@@ -286,8 +286,10 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     private func startMonitoringLocation() {
         if shouldUseSignificantUpdateService() {
             manager.startMonitoringSignificantLocationChanges()
+            manager.stopUpdatingLocation()
         } else {
             manager.startUpdatingLocation()
+            manager.stopMonitoringSignificantLocationChanges()
         }
     }
     
@@ -338,7 +340,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     }
     
     private func calculateAndUpdateAccuracy() {
-        var computedAccuracy: LocationAccuracy = accuracy
+        var computedAccuracy = accuracy
         
         // Map location listeners to get an array of accuracy raw values
         let accuracyRawValues = allLocationListeners.map({ (aLocationListener: LocationListener) -> Int in
@@ -358,15 +360,20 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         if accuracy != computedAccuracy {
             accuracy = computedAccuracy
             
+            // Use a distance filter to ignore unnecessary updates so the app can sleep more often
             switch accuracy {
             case .Coarse:
                 manager.desiredAccuracy = kCLLocationAccuracyKilometer
+                manager.distanceFilter = 500
             case .Good:
                 manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+                manager.distanceFilter = 50
             case .Better:
                 manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+                manager.distanceFilter = 5
             case .Best:
                 manager.desiredAccuracy = kCLLocationAccuracyBest
+                manager.distanceFilter = 2
             }
         }
     }

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -360,21 +360,24 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         if accuracy != computedAccuracy {
             accuracy = computedAccuracy
             
-            // Use a distance filter to ignore unnecessary updates so the app can sleep more often
             switch accuracy {
             case .Coarse:
                 manager.desiredAccuracy = kCLLocationAccuracyKilometer
-                manager.distanceFilter = 500
             case .Good:
                 manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-                manager.distanceFilter = 50
             case .Better:
                 manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
-                manager.distanceFilter = 5
             case .Best:
                 manager.desiredAccuracy = kCLLocationAccuracyBest
-                manager.distanceFilter = 2
             }
+            
+            // Use a distance filter to ignore unnecessary updates so the app can sleep more often
+            // NOTE: A distance filter of half the accuracy allows some updates while the device is
+            //       stationary (caused by GPS fluctuations) in an attempt to ensure timely updates
+            //       while the device is moving (so previous inaccuracies can be corrected). A minimum
+            //       of two meters is good for best accuracy, which evaluates to zero but typically
+            //       generates updates with an accuracy of ±5m in practice.
+            manager.distanceFilter = max(2, manager.desiredAccuracy / 2)
         }
     }
     

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -30,4 +30,22 @@ class ELLocationTests: XCTestCase {
         // no crash here is a test success
         LocationManager.shared.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: 42, longitude: 42)])
     }
+    
+    func testDistanceFilterShouldChangeWithAccuracy() {
+        let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
+        
+        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, kCLDistanceFilterNone)
+        
+        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
+        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 500)
+        
+        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Good, response: handler))
+        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 50)
+        
+        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Better, response: handler))
+        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 5)
+        
+        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Best, response: handler))
+        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 2)
+    }
 }


### PR DESCRIPTION
Doing this lets undesired location updates be ignored by the app, allowing it to sleep. Added unit test and made the location manager property internal instead of private so that it can be used from the unit tests. Attempted fix for #6.
