### PR TITLE
Update ELLocation LocationManager to improve thread safety

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -52,6 +52,10 @@ public enum LocationAccuracy: Int {
     case Best
 }
 
+private func < (lhs: LocationAccuracy, rhs: LocationAccuracy) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}
+
 /**
 Callback frequency setting. Lowest power consumption is achieved by combining LocationUpdateFrequency.ChangesOnly
  with LocationAccuracy.Coarse
@@ -62,6 +66,10 @@ Callback frequency setting. Lowest power consumption is achieved by combining Lo
 public enum LocationUpdateFrequency: Int {
     case ChangesOnly
     case Continuous
+}
+
+private func < (lhs: LocationUpdateFrequency, rhs: LocationUpdateFrequency) -> Bool {
+    return lhs.rawValue < rhs.rawValue
 }
 
 public enum LocationAuthorization {
@@ -252,7 +260,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     private var accuracy: LocationAccuracy {
         let allAccuracies = allLocationListeners.map({ $0.request.accuracy })
 
-        guard let value = allAccuracies.maxElement({ $0.rawValue < $1.rawValue }) else {
+        guard let value = allAccuracies.maxElement(<) else {
             return .Good
         }
 
@@ -263,7 +271,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     private var updateFrequency: LocationUpdateFrequency {
         let allUpdateFrequencies = allLocationListeners.map({ $0.request.updateFrequency })
 
-        guard let value = allUpdateFrequencies.maxElement({ $0.rawValue < $1.rawValue }) else {
+        guard let value = allUpdateFrequencies.maxElement(<) else {
             return .ChangesOnly
         }
 

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -435,13 +435,8 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             // Use a distance filter to ignore unnecessary updates so the app can sleep more often
             manager.distanceFilter = self.coreLocationDistanceFilter
 
-            let monitoring = self.monitoring
-
-            if monitoring == .None {
-                manager.stopUpdatingLocation()
-                manager.stopMonitoringSignificantLocationChanges()
-            } else {
-                switch monitoring! {
+            if let monitoring = self.monitoring {
+                switch monitoring {
                 case .SignificantUpdates:
                     manager.startMonitoringSignificantLocationChanges()
                     manager.stopUpdatingLocation()
@@ -449,6 +444,9 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
                     manager.startUpdatingLocation()
                     manager.stopMonitoringSignificantLocationChanges()
                 }
+            } else {
+                manager.stopUpdatingLocation()
+                manager.stopMonitoringSignificantLocationChanges()
             }
         }
     }

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -447,7 +447,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
                     manager.stopUpdatingLocation()
                 case .Standard:
                     manager.startUpdatingLocation()
-                    manager.stopUpdatingLocation()
+                    manager.stopMonitoringSignificantLocationChanges()
                 }
             }
         }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -34,18 +34,20 @@ class ELLocationTests: XCTestCase {
     func testDistanceFilterShouldChangeWithAccuracy() {
         let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
         
-        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, kCLDistanceFilterNone)
+        let subject = LocationManager()
         
-        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
-        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 500)
+        XCTAssertEqual(subject.manager.distanceFilter, kCLDistanceFilterNone)
         
-        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Good, response: handler))
-        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 50)
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
+        XCTAssertEqual(subject.manager.distanceFilter, 500)
         
-        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Better, response: handler))
-        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 5)
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Good, response: handler))
+        XCTAssertEqual(subject.manager.distanceFilter, 50)
         
-        LocationManager.shared.registerListener(self, request: LocationUpdateRequest(accuracy: .Best, response: handler))
-        XCTAssertEqual(LocationManager.shared.manager.distanceFilter, 2)
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Better, response: handler))
+        XCTAssertEqual(subject.manager.distanceFilter, 5)
+        
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Best, response: handler))
+        XCTAssertEqual(subject.manager.distanceFilter, 2)
     }
 }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -40,14 +40,18 @@ class ELLocationTests: XCTestCase {
         
         subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
         XCTAssertEqual(subject.manager.distanceFilter, 500)
+        subject.deregisterListener(self)
         
         subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Good, response: handler))
         XCTAssertEqual(subject.manager.distanceFilter, 50)
+        subject.deregisterListener(self)
         
         subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Better, response: handler))
         XCTAssertEqual(subject.manager.distanceFilter, 5)
+        subject.deregisterListener(self)
         
         subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Best, response: handler))
         XCTAssertEqual(subject.manager.distanceFilter, 2)
+        subject.deregisterListener(self)
     }
 }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -33,11 +33,10 @@ class ELLocationTests: XCTestCase {
     
     func testDistanceFilterShouldChangeWithAccuracy() {
         let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
-        
         let subject = LocationManager()
         
-        XCTAssertEqual(subject.manager.distanceFilter, kCLDistanceFilterNone)
-        
+        // Note: behavior with no listeners is not defined.
+
         subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
         XCTAssertEqual(subject.manager.distanceFilter, 500)
         subject.deregisterListener(self)

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -53,4 +53,27 @@ class ELLocationTests: XCTestCase {
         XCTAssertEqual(subject.manager.distanceFilter, 2)
         subject.deregisterListener(self)
     }
+    
+    func testDesiredAccuracyShouldChangeWithAccuracy() {
+        let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
+        let subject = LocationManager()
+        
+        // Note: behavior with no listeners is not defined.
+
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
+        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyKilometer)
+        subject.deregisterListener(self)
+        
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Good, response: handler))
+        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyHundredMeters)
+        subject.deregisterListener(self)
+        
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Better, response: handler))
+        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyNearestTenMeters)
+        subject.deregisterListener(self)
+        
+        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Best, response: handler))
+        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyBest)
+        subject.deregisterListener(self)
+    }
 }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -23,6 +23,26 @@ class ELLocationTests: XCTestCase {
         super.tearDown()
     }
     
+    private func deliverLocationUpdate(subject: LocationManager, latitude: CLLocationDegrees, longitude: CLLocationDegrees) {
+        subject.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: latitude, longitude: longitude)])
+    }
+    
+    func testAddListener() {
+        let subject = LocationManager()
+        let listener = NSObject()
+
+        let responseReceived = expectationWithDescription("response received")
+        let request = LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in
+            responseReceived.fulfill()
+        }
+
+        subject.registerListener(listener, request:request)
+        
+        deliverLocationUpdate(subject, latitude: 42, longitude: 42)
+        
+        waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+    
     func testCalculateAndUpdateAccuracyCrash() {
         LocationAuthorizationService().requestAuthorization(.WhenInUse)
         LocationAuthorizationService().requestAuthorization(.Always)


### PR DESCRIPTION
#### What does this PR do?

Changes some of the design of the internal `ELLocation.LocationManager` so that the data flow is more clear, and improves thread safety.
#### Any background context you want to provide?

This is a bigger change than I had initially intended to make. I started looking into fixing a thread-safety issue in `deregisterListener`:

``` swift
    func deregisterListener(listener: AnyObject) {
        if let theIndex = indexOfLocationListenerForListener(listener) {
            removeLocationListenerAtIndex(theIndex)
        }
    }
```

There was no `synchronized` call in this method (but there were calls in `indexOf…` and `removeLocationListener…`). Effectively, the code worked like this:
1. Acquire lock.
2. Find index of listener.
3. Release lock.
4. Reacquire lock.
5. Remove listener using index from step (2)
6. Release lock.

Between steps (3) and (4) the listener array could have been modified, invalidating the index.

As I tried to implement that, I realized that there were several places where state changes were originating, which made them difficult to isolate and synchronize.

I ended up redesigning the internals of `ELLocation.LocationManager` so that changes to the internal state go through one central "reducer" that then updates the single internal `CLLocationManager`'s state. All access to internal state is `synchronized` to make it thread safe.

The "reducer" data flow works like this:

Inputs:
- Array of listeners with `accuracy` and `updateFrequency`.
- Core location authorization status.

Intermediates:
- Maximum accuracy from the listeners.
- Maximum update frequency from the listeners.

Outputs:
- Desired accuracy for the underlying location manager.
- Distance filter for the location manager.
- Location updates on/off.
- Significant change monitoring on/off.
#### Where should the reviewer start?
- Most of the changes are to the `LocationManager` class.
- I also added a new private enum for the two different location monitoring modes ("significant updates" and "standard").
- Most of the state reduction happens through series of computed properties. For example, the `coreLocationDesireAccuracy` is computed from the `accuracy`, which is computed from `allLocationListeners`.
#### How should this be manually tested?

There is a sample app in the project. If you run the sample app using the old version and this new version, they should behave the same.
