### PR TITLE
Add Unit Tests

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -426,9 +426,9 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         
         let locationListener = LocationListener(listener: listener, request: request)
         
-        synchronized(self, closure: { () -> Void in
+        synchronized(self) {
             self.allLocationListeners.append(locationListener)
-        })
+        }
 
         updateLocationMonitoring()
 

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -276,8 +276,8 @@ This is the internal class that is set up as a singleton that interfaces with `C
 the protocols that define `ELLocation` services in the public API.
 */
 class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationProvider, CLLocationManagerDelegate {
-    static let shared: LocationManager = LocationManager()
-    
+    private static let shared: LocationManager = LocationManager()
+
     // MARK: Properties, initializers and internal structures
     
     var manager: ELCLLocationManager

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -292,7 +292,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
 
     // MARK: Properties, initializers and internal structures
     
-    var manager: ELCLLocationManager
+    private var manager: ELCLLocationManager
     private var allLocationListeners: [LocationListener]
 
     /// The current Core Location authorization status

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -345,7 +345,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         }
     }
 
-    /// The underlying location manager's desired distance filter for the current state.
+    /// The underlying location manager's distance filter for the current state.
     private var coreLocationDistanceFilter: CLLocationDistance {
         // NOTE: A distance filter of half the accuracy allows some updates while the device is
         //       stationary (caused by GPS fluctuations) in an attempt to ensure timely updates

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -387,7 +387,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         manager.delegate = self
     }
     
-    class LocationListener {
+    private class LocationListener {
         static let locationChangeThresholdMeters: [LocationAccuracy: CLLocationDistance] = [
             .Best: 0,
             .Better: 10,

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -140,6 +140,18 @@ private extension CLAuthorizationStatus {
             return false
         }
     }
+
+    /**
+     Whether this authorization status allows any form of monitoring.
+     */
+    var allowsMonitoring: Bool {
+        switch self {
+        case .NotDetermined, .Denied, .Restricted:
+            return false
+        default:
+            return true
+        }
+    }
 }
 
 // MARK: Location Authorization API
@@ -313,6 +325,10 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     /// The monitoring mode for the current state.
     private var monitoring: LocationMonitoring? {
         guard !allLocationListeners.isEmpty else {
+            return nil
+        }
+
+        guard authorizationStatus.allowsMonitoring else {
             return nil
         }
 

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -310,50 +310,78 @@ class ELLocationTests: XCTestCase {
     // MARK: Distance filter
 
     func testDistanceFilterShouldChangeWithAccuracy() {
-        let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
-        let subject = LocationManager()
-        
+        let manager = MockCLLocationManager()
+        let subject = LocationManager(manager: manager)
+
+        let coarseListener = NSObject()
+        let goodListener = NSObject()
+        let betterListener = NSObject()
+        let bestListener = NSObject()
+
         // Note: behavior with no listeners is not defined.
 
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
-        XCTAssertEqual(subject.manager.distanceFilter, 500)
-        subject.deregisterListener(self)
-        
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Good, response: handler))
-        XCTAssertEqual(subject.manager.distanceFilter, 50)
-        subject.deregisterListener(self)
-        
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Better, response: handler))
-        XCTAssertEqual(subject.manager.distanceFilter, 5)
-        subject.deregisterListener(self)
-        
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Best, response: handler))
-        XCTAssertEqual(subject.manager.distanceFilter, 2)
-        subject.deregisterListener(self)
+        // Add listeners from lowest to highest accuracy and verify that distance filter decreases:
+
+        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.distanceFilter, 500)
+
+        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.distanceFilter, 50)
+
+        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.distanceFilter, 5)
+
+        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.distanceFilter, 2)
+
+        // Remove listeners from lowest to highest accuracy and verify that distance filter DOES NOT CHANGE:
+
+        subject.deregisterListener(coarseListener)
+        XCTAssertEqual(manager.distanceFilter, 2)
+
+        subject.deregisterListener(goodListener)
+        XCTAssertEqual(manager.distanceFilter, 2)
+
+        subject.deregisterListener(betterListener)
+        XCTAssertEqual(manager.distanceFilter, 2)
     }
-    
-    // MARK: Desired accuracy
 
+    // MARK: Desired accuracy
+    
     func testDesiredAccuracyShouldChangeWithAccuracy() {
-        let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
-        let subject = LocationManager()
-        
+        let manager = MockCLLocationManager()
+        let subject = LocationManager(manager: manager)
+
+        let coarseListener = NSObject()
+        let goodListener = NSObject()
+        let betterListener = NSObject()
+        let bestListener = NSObject()
+
         // Note: behavior with no listeners is not defined.
 
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Coarse, response: handler))
-        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyKilometer)
-        subject.deregisterListener(self)
-        
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Good, response: handler))
-        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyHundredMeters)
-        subject.deregisterListener(self)
-        
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Better, response: handler))
-        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyNearestTenMeters)
-        subject.deregisterListener(self)
-        
-        subject.registerListener(self, request: LocationUpdateRequest(accuracy: .Best, response: handler))
-        XCTAssertEqual(subject.manager.desiredAccuracy, kCLLocationAccuracyBest)
-        subject.deregisterListener(self)
+        // Add listeners from lowest to highest accuracy and verify that desired accuracy increases:
+
+        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyKilometer)
+
+        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyHundredMeters)
+
+        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyNearestTenMeters)
+
+        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { (success, location, error) -> Void in })
+        XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyBest)
+
+        // Remove listeners from lowest to highest accuracy and verify that desired accuracy DOES NOT CHANGE:
+
+        subject.deregisterListener(coarseListener)
+        XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyBest)
+
+        subject.deregisterListener(goodListener)
+        XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyBest)
+
+        subject.deregisterListener(betterListener)
+        XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyBest)
     }
 }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -76,7 +76,8 @@ extension LocationManager {
         let listener = NSObject()
         let request = LocationUpdateRequest(accuracy: accuracy, updateFrequency: updateFrequency) { (success, location, error) -> Void in }
 
-        registerListener(listener, request: request)
+        let error = registerListener(listener, request: request)
+        XCTAssertNil(error, "Must be able to register a mock listener")
 
         closure()
 

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -11,6 +11,44 @@ import XCTest
 import CoreLocation
 @testable import ELLocation
 
+class MockCLLocationManager: ELCLLocationManager {
+    var coreLocationServicesEnabled: Bool = true
+    var coreLocationAuthorizationStatus: CLAuthorizationStatus = .NotDetermined
+    var requestedAuthorizationStatus: CLAuthorizationStatus? = nil
+
+    var desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyBest
+    var distanceFilter: CLLocationDistance = kCLDistanceFilterNone
+    
+    var updatingLocation: Bool = false
+    var monitoringSignificantLocationChanges: Bool = false
+
+    weak var delegate: CLLocationManagerDelegate? = nil
+
+    func requestAlwaysAuthorization() {
+        requestedAuthorizationStatus = .AuthorizedAlways
+    }
+
+    func requestWhenInUseAuthorization() {
+        requestedAuthorizationStatus = .AuthorizedWhenInUse
+    }
+    
+    func startUpdatingLocation() {
+        updatingLocation = true
+    }
+
+    func stopUpdatingLocation() {
+        updatingLocation = false
+    }
+
+    func startMonitoringSignificantLocationChanges() {
+        monitoringSignificantLocationChanges = true
+    }
+
+    func stopMonitoringSignificantLocationChanges() {
+        monitoringSignificantLocationChanges = false
+    }
+}
+
 class ELLocationTests: XCTestCase {
     
     override func setUp() {

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -90,7 +90,11 @@ class ELLocationTests: XCTestCase {
         // no crash here is a test success
         subject.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: 42, longitude: 42)])
     }
+
+    // MARK: Listeners
     
+    // MARK: Distance filter
+
     func testDistanceFilterShouldChangeWithAccuracy() {
         let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
         let subject = LocationManager()
@@ -114,6 +118,8 @@ class ELLocationTests: XCTestCase {
         subject.deregisterListener(self)
     }
     
+    // MARK: Desired accuracy
+
     func testDesiredAccuracyShouldChangeWithAccuracy() {
         let handler: LocationUpdateResponseHandler = { (success: Bool, location: CLLocation?, error: NSError?) in }
         let subject = LocationManager()

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -49,6 +49,37 @@ class MockCLLocationManager: ELCLLocationManager {
     }
 }
 
+// Convenience methods for testing:
+
+extension MockCLLocationManager {
+    func withServicesEnabled(enabled: Bool, closure: () -> Void) {
+        let oldEnabled = coreLocationServicesEnabled
+        coreLocationServicesEnabled = enabled
+        closure()
+        coreLocationServicesEnabled = oldEnabled
+    }
+
+    func withAuthorizationStatus(status: CLAuthorizationStatus, closure: () -> Void) {
+        let oldStatus = coreLocationAuthorizationStatus
+        coreLocationAuthorizationStatus = status
+        closure()
+        coreLocationAuthorizationStatus = oldStatus
+    }
+}
+
+extension LocationManager {
+    func withListener(accuracy accuracy: LocationAccuracy, updateFrequency: LocationUpdateFrequency, closure: () -> Void) {
+        let listener = NSObject()
+        let request = LocationUpdateRequest(accuracy: accuracy, updateFrequency: updateFrequency) { (success, location, error) -> Void in }
+
+        registerListener(listener, request: request)
+
+        closure()
+
+        deregisterListener(listener)
+    }
+}
+
 class ELLocationTests: XCTestCase {
     
     override func setUp() {

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -292,19 +292,21 @@ class ELLocationTests: XCTestCase {
         let manager = MockCLLocationManager()
         let subject = LocationManager(manager: manager)
 
-        XCTAssertFalse(manager.updatingLocation, "Before adding listeners, location is not updating (GPS)")
-
-        subject.withListener(accuracy: .Good, updateFrequency: .Continuous) {
-            XCTAssertTrue(manager.updatingLocation, "Adding a listener initiates location updates")
+        manager.withAuthorizationStatus(.AuthorizedWhenInUse) {
+            XCTAssertFalse(manager.updatingLocation, "Before adding listeners, location is not updating (GPS)")
 
             subject.withListener(accuracy: .Good, updateFrequency: .Continuous) {
-                XCTAssertTrue(manager.updatingLocation, "Adding a second listener continues location updates")
+                XCTAssertTrue(manager.updatingLocation, "Adding a listener initiates location updates")
+
+                subject.withListener(accuracy: .Good, updateFrequency: .Continuous) {
+                    XCTAssertTrue(manager.updatingLocation, "Adding a second listener continues location updates")
+                }
+
+                XCTAssertTrue(manager.updatingLocation, "Removing second listener does not stop location updates")
             }
 
-            XCTAssertTrue(manager.updatingLocation, "Removing second listener does not stop location updates")
+            XCTAssertFalse(manager.updatingLocation, "Removing all listeners stop location updates")
         }
-
-        XCTAssertFalse(manager.updatingLocation, "Removing all listeners stop location updates")
     }
     
     // MARK: Distance filter

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -85,8 +85,10 @@ class ELLocationTests: XCTestCase {
         LocationAuthorizationService().requestAuthorization(.WhenInUse)
         LocationAuthorizationService().requestAuthorization(.Always)
         
+        let subject = LocationManager()
+
         // no crash here is a test success
-        LocationManager.shared.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: 42, longitude: 42)])
+        subject.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: 42, longitude: 42)])
     }
     
     func testDistanceFilterShouldChangeWithAccuracy() {

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -95,23 +95,7 @@ class ELLocationTests: XCTestCase {
     private func deliverLocationUpdate(subject: LocationManager, latitude: CLLocationDegrees, longitude: CLLocationDegrees) {
         subject.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: latitude, longitude: longitude)])
     }
-    
-    func testAddListener() {
-        let subject = LocationManager()
-        let listener = NSObject()
 
-        let responseReceived = expectationWithDescription("response received")
-        let request = LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in
-            responseReceived.fulfill()
-        }
-
-        subject.registerListener(listener, request:request)
-        
-        deliverLocationUpdate(subject, latitude: 42, longitude: 42)
-        
-        waitForExpectationsWithTimeout(1.0, handler: nil)
-    }
-    
     func testCalculateAndUpdateAccuracyCrash() {
         LocationAuthorizationService().requestAuthorization(.WhenInUse)
         LocationAuthorizationService().requestAuthorization(.Always)


### PR DESCRIPTION
#### What does this PR do?

Adds unit test coverage for much, but not all, of `ELLocation.LocationManager`'s behavior.

Also, **this PR contains one functional change** ([commit](https://github.com/Electrode-iOS/ELLocation/commit/8540528133afcdd74ec41ecf00880efa8d117215)). The code no longer tries to receive location updates when the authorization status is Not Determined, Denied or Restricted.
#### Any background context you want to provide?

In order to allow mocking of the `CLLocationManager` behavior, I made the following changes:
- Created internal `ELCLLocationManager` protocol that covers all of the `CLLocationManager` APIs that are used.
- Added an extension to `CLLocationManager` that implements this protocol.
- Added an internal initializer that allows the underlying location `manager` to be passed in (i.e. injected).
- In the tests, created a new class, `MockCLLocationManager` that implements `ELCLLocationManager` with support for faking movement and inspecting state.
