### PR TITLE
Default vals for Location Update Request initializer args

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -195,20 +195,13 @@ public struct LocationUpdateRequest {
     let response: LocationUpdateResponseHandler
     
     /**
-    Convenience initializer defaulting updateFrequency to .Continuous
-    */
-    public init(accuracy: LocationAccuracy, response: LocationUpdateResponseHandler) {
-        self.init(accuracy: accuracy, updateFrequency: .Continuous, response: response)
-    }
-    
-    /**
-    Initializes a request to be used for registering for location updates.
-    
-    - parameter accuracy: The accuracy desired by the listener. Since there can be multiple listeners, the framework endeavors to provide the highest level of accuracy registered.
-    - parameter updateFrequency: The rate at which to notify the listener
-    - parameter response: This closure is called when a update is received or if there's an error.
-    */
-    public init(accuracy: LocationAccuracy, updateFrequency: LocationUpdateFrequency, response: LocationUpdateResponseHandler) {
+     Initializes a request to be used for registering for location updates.
+
+     - parameter accuracy: The accuracy desired by the listener. Since there can be multiple listeners, the framework endeavors to provide the highest level of accuracy registered. Default value is `.Good`
+     - parameter updateFrequency: The rate at which to notify the listener. Default value is `.Continuous`.
+     - parameter response: This closure is called when a update is received or if there's an error.
+     */
+    public init(accuracy: LocationAccuracy = .Good, updateFrequency: LocationUpdateFrequency = .Continuous, response: LocationUpdateResponseHandler) {
         self.accuracy = accuracy
         self.response = response
         self.updateFrequency = updateFrequency

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -133,7 +133,7 @@ class ELLocationTests: XCTestCase {
         let manager = MockCLLocationManager()
         let subject = LocationManager(manager: manager)
         let listener = NSObject()
-        let request = LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in }
+        let request = LocationUpdateRequest() { (success, location, error) -> Void in }
         
         manager.withMockServicesEnabled(false) {
             let error1 = subject.registerListener(listener, request: request)
@@ -154,7 +154,7 @@ class ELLocationTests: XCTestCase {
         let done = expectationWithDescription("test finished")
 
         var responseReceived = false
-        let request = LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in
+        let request = LocationUpdateRequest() { (success, location, error) -> Void in
             responseReceived = true
         }
 
@@ -201,7 +201,7 @@ class ELLocationTests: XCTestCase {
         let done = expectationWithDescription("test finished")
 
         var responseReceived = false
-        let request = LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in
+        let request = LocationUpdateRequest() { (success, location, error) -> Void in
             responseReceived = true
         }
 


### PR DESCRIPTION
#### What does this PR do?

This is a vanity PR. I added default values for the `accuracy` and `updateFrequency` arguments of `LocationUpdateRequest.init()` so that a single initializer could cover:
- `LocationUpdateRequest(response: { … })`
- `LocationUpdateRequest(accuracy: .Best, response: { … })`
- `LocationUpdateRequest(updateFrequency: .ChangesOnly, response: { … })`
- `LocationUpdateRequest(accuracy: .Best, updateFrequency: .ChangesOnly, response: { … })`
