### PR TITLE
Default to "changes only" location updates

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -207,7 +207,7 @@ public struct LocationUpdateRequest {
      - parameter updateFrequency: The rate at which to notify the listener. Default value is `.Continuous`.
      - parameter response: This closure is called when a update is received or if there's an error.
      */
-    public init(accuracy: LocationAccuracy = .Good, updateFrequency: LocationUpdateFrequency = .Continuous, response: LocationUpdateResponseHandler) {
+    public init(accuracy: LocationAccuracy = .Good, updateFrequency: LocationUpdateFrequency = .ChangesOnly, response: LocationUpdateResponseHandler) {
         self.accuracy = accuracy
         self.response = response
         self.updateFrequency = updateFrequency


### PR DESCRIPTION
#### What does this PR do?

Switches the default update frequency to "changes only" (currently it is "continuous").

**Important: This is a breaking change.** Is it still possible to add this in 1.x, since 1.0.0 was just released?
#### Any background context you want to provide?

The main motivation for this is that it only takes a single request for "continuous" updates to force the location services into continuous update mode, which is more battery-intensive. Since most people tend to use default behaviors, making "changes only" the default will make it more likely that location services can remain in a lower power mode.

**Important:** This is a breaking change. Is it possible to get this in to 1.x, since 1.0.0 was just made a day or so ago?
#### How should this be manually tested?

Create a location update request with the default value for `updateFrequency`. Your response handler should _not_ receive continuous updates.
