### PR TITLE
No filter for continous updates

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -368,6 +368,11 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
 
     /// The underlying location manager's distance filter for the current state.
     private var coreLocationDistanceFilter: CLLocationDistance {
+        // To receive continuous updates, there must not be a distance filter.
+        guard updateFrequency != .Continuous else {
+            return kCLDistanceFilterNone
+        }
+
         // NOTE: A distance filter of half the accuracy allows some updates while the device is
         //       stationary (caused by GPS fluctuations) in an attempt to ensure timely updates
         //       while the device is moving (so previous inaccuracies can be corrected).

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -383,6 +383,18 @@ class ELLocationTests: XCTestCase {
     
     // MARK: Distance filter
 
+    func testContinuousUpdatesDisablesDistanceFilter() {
+        for accuracy: LocationAccuracy in [.Coarse, .Good, .Better, .Best] {
+            let manager = MockCLLocationManager()
+            let provider = LocationManager(manager: manager)
+            let subject = LocationUpdateService(locationProvider: provider)
+            
+            subject.withMockListener(accuracy: accuracy, updateFrequency: .Continuous) {
+                XCTAssertEqual(manager.distanceFilter, kCLDistanceFilterNone)
+            }
+        }
+    }
+
     func testDistanceFilterShouldChangeWithAccuracy() {
         let manager = MockCLLocationManager()
         let provider = LocationManager(manager: manager)

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -397,16 +397,16 @@ class ELLocationTests: XCTestCase {
 
         // Add listeners from lowest to highest accuracy and verify that distance filter decreases:
 
-        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { (success, location, error) -> Void in })
+        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { _,_,_ in })
         XCTAssertEqual(manager.distanceFilter, 500)
 
-        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in })
+        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { _,_,_ in })
         XCTAssertEqual(manager.distanceFilter, 50)
 
-        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { (success, location, error) -> Void in })
+        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { _,_,_ in })
         XCTAssertEqual(manager.distanceFilter, 5)
 
-        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { (success, location, error) -> Void in })
+        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { _,_,_ in })
         XCTAssertEqual(manager.distanceFilter, 2)
 
         // Remove listeners from lowest to highest accuracy and verify that distance filter DOES NOT CHANGE:


### PR DESCRIPTION
#### What does this PR do?

Turns of the distance filtering when continuous updates are requested.
#### Any background context you want to provide?

A while ago, in PR #7, we added automatic distance filtering based on the desired accuracy. However, applying a distance filter prevents the app from receiving continuous updates.
#### Where should the reviewer start?

Pretty simple change: I just updated the `coreLocationDistanceFilter` computation to return `kCLDistanceFilterNone` whenever the computed update frequency is "continuous". Distance filtering is still applied before notifying each listener, so this shouldn't affect that.
#### How should this be manually tested?

Create a `LocationUpdateRequest` with `updateFrequency` set to `.Continuous`. Your response handler should receive regular, periodic callbacks (every second or so).
