### PR TITLE
Accept "always" authorization when requesting "when in use"

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -477,9 +477,8 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         case .NotDetermined:
             requestAuth = true
         case .AuthorizedAlways:
-            if authorization != .Always {
-                return NSError(ELLocationError.AuthorizationAlways)
-            }
+            // Note: .AuthorizedAlways is good for both .Always and .WhenInUse
+            break
         case .AuthorizedWhenInUse:
             if authorization != .WhenInUse {
                 return NSError(ELLocationError.AuthorizationWhenInUse)

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -18,8 +18,6 @@ public enum ELLocationError: Int, NSErrorEnum {
     case AuthorizationDeniedOrRestricted
     /// The caller is asking for authorization 'always' but user has granted 'when in use'.
     case AuthorizationWhenInUse
-    /// The caller is asking for authorization 'when in use' but user has granted 'always'.
-    case AuthorizationAlways
     /// Location services are disabled.
     case LocationServicesDisabled
     
@@ -33,8 +31,6 @@ public enum ELLocationError: Int, NSErrorEnum {
             return "The user has denied location services in Settings or has been restricted from using them."
         case .AuthorizationWhenInUse:
             return "The user has granted permission to location services only when the app is in use."
-        case .AuthorizationAlways:
-            return "The user has granted permission to location services always, so use that or change it."
         case .LocationServicesDisabled:
             return "Location services are not enabled."
         }

--- a/ELLocationExample/AppDelegate.swift
+++ b/ELLocationExample/AppDelegate.swift
@@ -18,8 +18,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         
-        if let anError = LocationAuthorizationService().requestAuthorization(.WhenInUse) {
+        if let requestAuthError = LocationAuthorizationService().requestAuthorization(.WhenInUse) {
             //TODO: Client needs to process error and re-request auth
+            print("REQUEST AUTH: error requesting authorization. error is \(requestAuthError.localizedDescription)")
         } else {
             startLocationUpdates()
         }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -274,11 +274,10 @@ class ELLocationTests: XCTestCase {
                     XCTAssertNil(error, "Request auth does not return error when authorization is undetermined")
                     XCTAssertEqual(manager.requestedAuthorization, authorization, "Requests auth when necessary")
                 case (true, .AuthorizedWhenInUse, .WhenInUse),
-                     (true, .AuthorizedAlways,    .Always):
+                     (true, .AuthorizedAlways, _):
                     XCTAssertNil(error, "Request auth does not return error already authorized")
                     XCTAssertNil(manager.requestedAuthorization, "Request auth does nothing when already authorized")
-                case (true, .AuthorizedWhenInUse, .Always),
-                     (true, .AuthorizedAlways,    .WhenInUse):
+                case (true, .AuthorizedWhenInUse, .Always):
                     XCTAssertNotNil(error, "Request auth returns error when existing authorization does not match requested authorization")
                     XCTAssertNil(manager.requestedAuthorization, "Request auth does nothing when existing authorization does not match requested authorization")
                 }


### PR DESCRIPTION
#### What does this PR do?

Updates `requestAuthorization()` to return successfully if the code requests "when in use" authorization and the user has already granted "always" authorization.

**Update:** Adds verification that a correct usage description has been provided. If not, `requestAuthorization()` returns an error.
#### Any background context you want to provide?

Always authorization is a superset of when-in-use authorization, so it makes sense for this to be considered a success.

**Update:** iOS doesn't provide a useful error message when authorization usage description is missing. Instead, it just fails silently.
#### How should this be manually tested?
1. Make an app that requests always authorization.
2. Run the app.
3. Grant authorization. 
4. Change the app to request when-in-use authorization.
5. Run the app.

The call to `requestAuthorization(.WhenInUse)` should succeed because "always" authorization has already been granted.

**Update:**
1. Edit "Info.plist" and remove the usage descriptions.
2. Run the app.

Instead of presenting an alert to allow access to location, you should see a log message for a request authorization error, like:

```
REQUEST AUTH: error requesting authorization. error is No description for the requested usage authorization has been provided in the app.
```
