### PR TITLE
Align distance filtering thresholds

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -365,13 +365,6 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     }
     
     private class LocationListener {
-        static let locationChangeThresholdMeters: [LocationAccuracy: CLLocationDistance] = [
-            .Best: 0,
-            .Better: 10,
-            .Good: 100,
-            .Coarse: 200
-        ]
-        
         weak var listener: AnyObject?
         var request: LocationUpdateRequest
         var previousCallbackLocation: CLLocation?
@@ -427,16 +420,14 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             }
         }
 
-        func shouldUpdateListenerForLocation(location: CLLocation) -> Bool {
-            switch request.updateFrequency {
-            case .Continuous:
+        func shouldUpdateListenerForLocation(currentLocation: CLLocation) -> Bool {
+            guard let previousLocation = previousCallbackLocation else {
                 return true
-            case .ChangesOnly:
-                if previousCallbackLocation == nil || previousCallbackLocation?.distanceFromLocation(location) >= LocationListener.locationChangeThresholdMeters[request.accuracy] {
-                    return true
-                }
-                return false
             }
+
+            let distance = previousLocation.distanceFromLocation(currentLocation)
+
+            return distance >= distanceFilter
         }
     }
     

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -45,14 +45,14 @@ public enum ELLocationError: Int, NSErrorEnum {
 More time and power is used going down this list as the system tries to provide a more accurate location,
 so be conservative according to your needs. `Good` should work well for most cases.
 */
-public enum LocationAccuracy: Int {
+public enum LocationAccuracy: Int, Comparable {
     case Coarse
     case Good
     case Better
     case Best
 }
 
-private func < (lhs: LocationAccuracy, rhs: LocationAccuracy) -> Bool {
+public func < (lhs: LocationAccuracy, rhs: LocationAccuracy) -> Bool {
     return lhs.rawValue < rhs.rawValue
 }
 
@@ -63,12 +63,12 @@ Callback frequency setting. Lowest power consumption is achieved by combining Lo
 - ChangesOnly: Notify listeners only when location changes. The granularity of this depends on the LocationAccuracy setting
 - Continuous:  Notify listeners at regular, frequent intervals (~1-2s)
 */
-public enum LocationUpdateFrequency: Int {
+public enum LocationUpdateFrequency: Int, Comparable {
     case ChangesOnly
     case Continuous
 }
 
-private func < (lhs: LocationUpdateFrequency, rhs: LocationUpdateFrequency) -> Bool {
+public func < (lhs: LocationUpdateFrequency, rhs: LocationUpdateFrequency) -> Bool {
     return lhs.rawValue < rhs.rawValue
 }
 

--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -328,7 +328,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     }
 
     /// The monitoring mode for the current state.
-    private var monitoring: LocationMonitoring? {
+    private var monitoringMode: LocationMonitoring? {
         guard !allLocationListeners.isEmpty else {
             return nil
         }
@@ -353,7 +353,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     }
 
     /// The underlying location manager's desired accuracy for the current state.
-    private var coreLocationDesiredAccuracy: CLLocationAccuracy {
+    private var desiredAccuracy: CLLocationAccuracy {
         switch accuracy {
         case .Coarse:
             return kCLLocationAccuracyKilometer
@@ -367,7 +367,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
     }
 
     /// The underlying location manager's distance filter for the current state.
-    private var coreLocationDistanceFilter: CLLocationDistance {
+    private var distanceFilter: CLLocationDistance {
         // To receive continuous updates, there must not be a distance filter.
         guard updateFrequency != .Continuous else {
             return kCLDistanceFilterNone
@@ -382,7 +382,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             // updates with an accuracy of ±5m in practice.
             return 2.0
         default:
-            return coreLocationDesiredAccuracy / 2
+            return desiredAccuracy / 2
         }
     }
 
@@ -500,12 +500,12 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         synchronized(self) {
             let manager = self.manager
 
-            manager.desiredAccuracy = self.coreLocationDesiredAccuracy
+            manager.desiredAccuracy = self.desiredAccuracy
 
             // Use a distance filter to ignore unnecessary updates so the app can sleep more often
-            manager.distanceFilter = self.coreLocationDistanceFilter
+            manager.distanceFilter = self.distanceFilter
 
-            if let monitoring = self.monitoring {
+            if let monitoring = self.monitoringMode {
                 switch monitoring {
                 case .SignificantUpdates:
                     manager.startMonitoringSignificantLocationChanges()

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -479,13 +479,13 @@ class ELLocationTests: XCTestCase {
         for accuracy: LocationAccuracy in [.Coarse, .Good, .Better, .Best] {
             let done = expectationWithDescription("\(accuracy) test finished")
 
-            testContinuousUpdates(accuracy, then: { done.fulfill() })
+            testContinuousUpdates(accuracy, then: done.fulfill)
         }
 
         waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
     }
 
-    func testContinuousUpdates(accuracy: LocationAccuracy, updateFrequency: LocationUpdateFrequency = .Continuous, then: () -> Void) {
+    func testContinuousUpdates(accuracy: LocationAccuracy, updateFrequency: LocationUpdateFrequency = .Continuous, then done: () -> Void) {
         let manager = MockCLLocationManager()
         let provider = LocationManager(manager: manager)
         let subject = LocationUpdateService(locationProvider: provider)
@@ -521,8 +521,7 @@ class ELLocationTests: XCTestCase {
                 // DON'T FORGET THIS! If the listener is dealloced, it will not receive callbacks
                 subject.deregisterListener(listener)
 
-                // Done
-                then()
+                done()
             }
         }
     }
@@ -535,16 +534,16 @@ class ELLocationTests: XCTestCase {
             let done = expectationWithDescription("\(accuracy) test finished")
 
             if threshold > 0 {
-                testDiscreteUpdates(accuracy, threshold: threshold, then: { done.fulfill() })
+                testDiscreteUpdates(accuracy, threshold: threshold, then: done.fulfill)
             } else {
-                testContinuousUpdates(accuracy, updateFrequency: .ChangesOnly, then: { done.fulfill() })
+                testContinuousUpdates(accuracy, updateFrequency: .ChangesOnly, then: done.fulfill)
             }
         }
 
         waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
     }
 
-    func testDiscreteUpdates(accuracy: LocationAccuracy, threshold: CLLocationDistance, then: () -> Void) {
+    func testDiscreteUpdates(accuracy: LocationAccuracy, threshold: CLLocationDistance, then done: () -> Void) {
         let manager = MockCLLocationManager()
         let provider = LocationManager(manager: manager)
         let subject = LocationUpdateService(locationProvider: provider)
@@ -591,8 +590,7 @@ class ELLocationTests: XCTestCase {
                     // DON'T FORGET THIS! If the listener is dealloced, it will not receive callbacks
                     subject.deregisterListener(listener)
                 
-                    // Done
-                    then()
+                    done()
                 }
             }
         }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -485,14 +485,14 @@ class ELLocationTests: XCTestCase {
         waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
     }
 
-    func testContinuousUpdates(accuracy: LocationAccuracy, updateFrequency: LocationUpdateFrequency = .Continuous, then done: () -> Void) {
+    func testContinuousUpdates(accuracy: LocationAccuracy, then done: () -> Void) {
         let manager = MockCLLocationManager()
         let provider = LocationManager(manager: manager)
         let subject = LocationUpdateService(locationProvider: provider)
         let listener = NSObject()
 
         var responseReceived = false
-        let request = LocationUpdateRequest(accuracy: accuracy, updateFrequency: updateFrequency) { (success, location, error) -> Void in
+        let request = LocationUpdateRequest(accuracy: accuracy, updateFrequency: .Continuous) { (success, location, error) -> Void in
             responseReceived = true
         }
 
@@ -528,16 +528,12 @@ class ELLocationTests: XCTestCase {
 
     func testDiscreteUpdates() {
         // Note: .Best has a threshold of 0m which means it always acts like "continuous"
-        let thresholds: [LocationAccuracy:CLLocationDistance] = [.Coarse: 200, .Good: 100, .Better: 10, .Best: 0]
+        let thresholds: [LocationAccuracy:CLLocationDistance] = [.Coarse: 500, .Good: 50, .Better: 5, .Best: 2]
 
         for (accuracy, threshold) in thresholds {
             let done = expectationWithDescription("\(accuracy) test finished")
 
-            if threshold > 0 {
-                testDiscreteUpdates(accuracy, threshold: threshold, then: done.fulfill)
-            } else {
-                testContinuousUpdates(accuracy, updateFrequency: .ChangesOnly, then: done.fulfill)
-            }
+            testDiscreteUpdates(accuracy, threshold: threshold, then: done.fulfill)
         }
 
         waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }


### PR DESCRIPTION
#### What does this PR do?

Updates the code so that there is a single set of distance filtering thresholds, unifying the previously-separate `distanceFilter` and `locationChangeThresholdMeters` values.

**Note: This PR changes the location update thresholds for the various accuracy values.**
#### Any background context you want to provide?

There were two competing distance filtering thresholds in the code: one used to set the `CLLocationManager.distanceFilter`, and one used by `LocationListener.shouldUpdateListenerForLocation()` to filter location updates.

Since the existing values were different, I had to choose one set. I decided to go with the values for the `distanceFilter`, since those were chosen to combine well with the accuracy values (although the others probably were, too).
#### Where should the reviewer start?

To support this, I [refactored the `LocationManager` a bit](https://github.com/Electrode-iOS/ELLocation/commit/81d12f53c8cfc5502ff1d4807c447dc6769d1592). Instead of calculating an `accuracy` and `updateFrequency` from the list of listeners and then computing `distanceFilter` and `desiredAccuracy` for the `CLLocationManager` from those, each `LocationListener` now calculates its own `distanceFilter` and `desiredAccuracy`, and the `LocationManger` just picks the appropriate (minimum) value.

After that, I [removed the `locationChangeThresholdMeters`](https://github.com/Electrode-iOS/ELLocation/commit/61ffbc18e5b4dab057c15a2decb35f6d1bf17121) and changed `shouldUpdateListenerForLocation()` to use the `distanceFilter` instead.
