### PR TITLE
Fix rapid location updates

### DIFF
--- a/ELLocation/LocationService.swift
+++ b/ELLocation/LocationService.swift
@@ -558,13 +558,12 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             let locationListeners = self.allLocationListeners
 
             for locationListener in locationListeners where locationListener.listener != nil {
-                // FIXME: previousCallbackLocation is assigned in the async block, but it is
-                // used in shouleUpdateListener() which creates a race condition.
                 if locationListener.shouldUpdateListenerForLocation(mostRecentLocation) {
+                    locationListener.previousCallbackLocation = mostRecentLocation
+
                     // Is it weird that the `response` handler can still receive callbacks even after the listener
                     // has been unregistered? I think that could happen with this design.
                     dispatch_async(dispatch_get_main_queue(), {
-                        locationListener.previousCallbackLocation = mostRecentLocation
                         locationListener.request.response(success: true, location: mostRecentLocation, error: nil)
                     })
                 }
@@ -579,7 +578,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             let locationListeners = self.allLocationListeners
 
             for locationListener in locationListeners where locationListener.listener != nil {
-                dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                dispatch_async(dispatch_get_main_queue(), {
                     locationListener.request.response(success: false, location: nil, error: error)
                 })
             }


### PR DESCRIPTION
#### What does this PR do?

Fixes a minor issue that could potentially cause a listener to receive more location updates than it requested. Note that this would probably never happen in practice because the `CLLocationManager` would not deliver updates quickly enough.
#### Any background context you want to provide?

The source of the issue was that the listener's `previousCallbackLocation` was not updated immediately when a qualifying location update was received. That created a race condition where another location could also be sent to the listener, even though the change was less than the requested distance filter.
#### Where should the reviewer start?

The fix was to move the assignment of the `previousCallbackLocation` out of the `dispatch_async` block so that it happens immediately.
#### How should this be manually tested?

There is a new test in the project (`testRapidLocationUpdates`) that fails with the old version of the code and passes with this updated version.
