### PR TITLE
Split `LocationService.swift` into separate files

### DIFF
--- a/ELLocation.xcodeproj/project.pbxproj
+++ b/ELLocation.xcodeproj/project.pbxproj
@@ -18,10 +18,18 @@
 		2280E15E1ABB4BEC0026F13A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2280E15D1ABB4BEC0026F13A /* Images.xcassets */; };
 		2280E1611ABB4BEC0026F13A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2280E15F1ABB4BEC0026F13A /* LaunchScreen.xib */; };
 		2280E16D1ABB4BEC0026F13A /* ELLocationExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2280E16C1ABB4BEC0026F13A /* ELLocationExampleTests.swift */; };
-		2280E1751ABB4C380026F13A /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2280E1741ABB4C380026F13A /* LocationService.swift */; };
 		2280E17E1ABB4D4B0026F13A /* ELLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2280E0EA1ABB47860026F13A /* ELLocation.framework */; };
 		2280E17F1ABB4D4B0026F13A /* ELLocation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2280E0EA1ABB47860026F13A /* ELLocation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		46FBD85B1C232F7B0000E733 /* ELFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 220E9E981B8BDFB4000863F6 /* ELFoundation.framework */; };
+		B6EC54931C99C7D900B795D9 /* ELLocationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC54921C99C7D900B795D9 /* ELLocationError.swift */; };
+		B6EC54991C99C7E400B795D9 /* LocationAccuracy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC54981C99C7E400B795D9 /* LocationAccuracy.swift */; };
+		B6EC549B1C99C7F100B795D9 /* LocationUpdateFrequency.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC549A1C99C7F100B795D9 /* LocationUpdateFrequency.swift */; };
+		B6EC549D1C99C84600B795D9 /* LocationAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC549C1C99C84600B795D9 /* LocationAuthorization.swift */; };
+		B6EC549F1C99C86100B795D9 /* LocationMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC549E1C99C86100B795D9 /* LocationMonitoring.swift */; };
+		B6EC54A11C99C8CD00B795D9 /* LocationAuthorizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC54A01C99C8CD00B795D9 /* LocationAuthorizationService.swift */; };
+		B6EC54A31C99C8ED00B795D9 /* LocationUpdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC54A21C99C8ED00B795D9 /* LocationUpdateRequest.swift */; };
+		B6EC54A51C99C92F00B795D9 /* LocationUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC54A41C99C92F00B795D9 /* LocationUpdateService.swift */; };
+		B6EC54A71C99C9B000B795D9 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC54A61C99C9B000B795D9 /* LocationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,7 +117,15 @@
 		2280E1661ABB4BEC0026F13A /* ELLocationExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ELLocationExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2280E16B1ABB4BEC0026F13A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2280E16C1ABB4BEC0026F13A /* ELLocationExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ELLocationExampleTests.swift; sourceTree = "<group>"; };
-		2280E1741ABB4C380026F13A /* LocationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
+		B6EC54921C99C7D900B795D9 /* ELLocationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ELLocationError.swift; sourceTree = "<group>"; };
+		B6EC54981C99C7E400B795D9 /* LocationAccuracy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationAccuracy.swift; sourceTree = "<group>"; };
+		B6EC549A1C99C7F100B795D9 /* LocationUpdateFrequency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationUpdateFrequency.swift; sourceTree = "<group>"; };
+		B6EC549C1C99C84600B795D9 /* LocationAuthorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationAuthorization.swift; sourceTree = "<group>"; };
+		B6EC549E1C99C86100B795D9 /* LocationMonitoring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationMonitoring.swift; sourceTree = "<group>"; };
+		B6EC54A01C99C8CD00B795D9 /* LocationAuthorizationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationAuthorizationService.swift; sourceTree = "<group>"; };
+		B6EC54A21C99C8ED00B795D9 /* LocationUpdateRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationUpdateRequest.swift; sourceTree = "<group>"; };
+		B6EC54A41C99C92F00B795D9 /* LocationUpdateService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationUpdateService.swift; sourceTree = "<group>"; };
+		B6EC54A61C99C9B000B795D9 /* LocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,7 +209,15 @@
 		2280E0EC1ABB47860026F13A /* ELLocation */ = {
 			isa = PBXGroup;
 			children = (
-				2280E1741ABB4C380026F13A /* LocationService.swift */,
+				B6EC54921C99C7D900B795D9 /* ELLocationError.swift */,
+				B6EC54981C99C7E400B795D9 /* LocationAccuracy.swift */,
+				B6EC549C1C99C84600B795D9 /* LocationAuthorization.swift */,
+				B6EC54A01C99C8CD00B795D9 /* LocationAuthorizationService.swift */,
+				B6EC54A61C99C9B000B795D9 /* LocationManager.swift */,
+				B6EC549E1C99C86100B795D9 /* LocationMonitoring.swift */,
+				B6EC549A1C99C7F100B795D9 /* LocationUpdateFrequency.swift */,
+				B6EC54A21C99C8ED00B795D9 /* LocationUpdateRequest.swift */,
+				B6EC54A41C99C92F00B795D9 /* LocationUpdateService.swift */,
 				2280E0EF1ABB47860026F13A /* ELLocation.h */,
 				2280E0ED1ABB47860026F13A /* Supporting Files */,
 			);
@@ -360,7 +384,7 @@
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0700;
-				ORGANIZATIONNAME = "WalmartLabs";
+				ORGANIZATIONNAME = WalmartLabs;
 				TargetAttributes = {
 					2280E0E91ABB47860026F13A = {
 						CreatedOnToolsVersion = 6.3;
@@ -474,7 +498,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2280E1751ABB4C380026F13A /* LocationService.swift in Sources */,
+				B6EC549D1C99C84600B795D9 /* LocationAuthorization.swift in Sources */,
+				B6EC54A51C99C92F00B795D9 /* LocationUpdateService.swift in Sources */,
+				B6EC54A71C99C9B000B795D9 /* LocationManager.swift in Sources */,
+				B6EC54A11C99C8CD00B795D9 /* LocationAuthorizationService.swift in Sources */,
+				B6EC54931C99C7D900B795D9 /* ELLocationError.swift in Sources */,
+				B6EC54A31C99C8ED00B795D9 /* LocationUpdateRequest.swift in Sources */,
+				B6EC549F1C99C86100B795D9 /* LocationMonitoring.swift in Sources */,
+				B6EC549B1C99C7F100B795D9 /* LocationUpdateFrequency.swift in Sources */,
+				B6EC54991C99C7E400B795D9 /* LocationAccuracy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ELLocation/ELLocationError.swift
+++ b/ELLocation/ELLocationError.swift
@@ -1,0 +1,40 @@
+//
+//  ELLocationError.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+import ELFoundation
+
+let ELLocationErrorDomain: String = "ELLocationErrorDomain"
+
+public enum ELLocationError: Int, NSErrorEnum {
+    /// The user has denied access to location services or their device has been configured to restrict it.
+    case AuthorizationDeniedOrRestricted
+    /// The callers is asking for authorization, but the corresponding description is missing from Info.plist
+    case UsageDescriptionMissing
+    /// The caller is asking for authorization 'always' but user has granted 'when in use'.
+    case AuthorizationWhenInUse
+    /// Location services are disabled.
+    case LocationServicesDisabled
+
+    public var domain: String {
+        return "io.theholygrail.ELLocationError"
+    }
+
+    public var errorDescription: String {
+        switch self {
+        case .AuthorizationDeniedOrRestricted:
+            return "The user has denied location services in Settings or has been restricted from using them."
+        case .UsageDescriptionMissing:
+            return "No description for the requested usage authorization has been provided in the app."
+        case .AuthorizationWhenInUse:
+            return "The user has granted permission to location services only when the app is in use."
+        case .LocationServicesDisabled:
+            return "Location services are not enabled."
+        }
+    }
+}
+

--- a/ELLocation/LocationAccuracy.swift
+++ b/ELLocation/LocationAccuracy.swift
@@ -1,0 +1,22 @@
+//
+//  LocationAccuracy.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+/**
+ More time and power is used going down this list as the system tries to provide a more accurate location,
+ so be conservative according to your needs. `Good` should work well for most cases.
+ */
+public enum LocationAccuracy: Int, Comparable {
+    case Coarse
+    case Good
+    case Better
+    case Best
+}
+
+public func < (lhs: LocationAccuracy, rhs: LocationAccuracy) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}

--- a/ELLocation/LocationAuthorization.swift
+++ b/ELLocation/LocationAuthorization.swift
@@ -1,0 +1,14 @@
+//
+//  LocationAuthorization.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+public enum LocationAuthorization {
+    /// Authorization for location services to be used only when the app is in use by the user.
+    case WhenInUse
+    /// Authorization for location services to be used at all times, even when the app is not in the foreground.
+    case Always
+}

--- a/ELLocation/LocationAuthorizationService.swift
+++ b/ELLocation/LocationAuthorizationService.swift
@@ -1,0 +1,35 @@
+//
+//  LocationAuthorizationService.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+// A protocol for a type that wants to provide location authorization.
+public protocol LocationAuthorizationProvider {
+    func requestAuthorization(authorization: LocationAuthorization) -> NSError?
+}
+
+// The interface for requesting location authorization
+public struct LocationAuthorizationService: LocationAuthorizationProvider {
+    private let locationAuthorizationProvider: LocationAuthorizationProvider
+
+    /**
+     Request the specified authorization.
+
+     - parameter authorization: The authorization being requested.
+     - returns: An optional error that could happen when requesting authorization. See `ELLocationError`.
+     */
+    public func requestAuthorization(authorization: LocationAuthorization) -> NSError? {
+        return locationAuthorizationProvider.requestAuthorization(authorization)
+    }
+
+    public init() {
+        self.init(locationAuthorizationProvider: LocationManager.shared)
+    }
+
+    init(locationAuthorizationProvider: LocationAuthorizationProvider) {
+        self.locationAuthorizationProvider = locationAuthorizationProvider
+    }
+}

--- a/ELLocation/LocationMonitoring.swift
+++ b/ELLocation/LocationMonitoring.swift
@@ -1,0 +1,27 @@
+//
+//  LocationMonitoring.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+/**
+ There are two kinds of location monitoring in iOS: significant updates and standard location monitoring.
+ Significant updates are more power efficient, but have limitations on accuracy and update frequency.
+ */
+enum LocationMonitoring: Comparable {
+    /// Monitor for only "significant updates" to the user's location (using cell towers only)
+    case SignificantUpdates
+    /// Monitor for all updates to the user's location (using GPS, WiFi, etc)
+    case Standard
+}
+
+func < (lhs: LocationMonitoring, rhs: LocationMonitoring) -> Bool {
+    switch (lhs, rhs) {
+    case (.SignificantUpdates, .Standard):
+        return true
+    default:
+        return false
+    }
+}

--- a/ELLocation/LocationUpdateFrequency.swift
+++ b/ELLocation/LocationUpdateFrequency.swift
@@ -1,0 +1,23 @@
+//
+//  LocationUpdateFrequency.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+/**
+ Callback frequency setting. Lowest power consumption is achieved by combining LocationUpdateFrequency.ChangesOnly
+ with LocationAccuracy.Coarse
+
+ - ChangesOnly: Notify listeners only when location changes. The granularity of this depends on the LocationAccuracy setting
+ - Continuous:  Notify listeners at regular, frequent intervals (~1-2s)
+*/
+public enum LocationUpdateFrequency: Int, Comparable {
+    case ChangesOnly
+    case Continuous
+}
+
+public func < (lhs: LocationUpdateFrequency, rhs: LocationUpdateFrequency) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}

--- a/ELLocation/LocationUpdateRequest.swift
+++ b/ELLocation/LocationUpdateRequest.swift
@@ -1,0 +1,37 @@
+//
+//  LocationUpdateRequest.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+import CoreLocation
+
+/**
+This handler is called when a location is updated or if there is an error.
+
+- parameter success: `true` if an updated location is available. `false` if there was an error.
+- parameter location: The location if `success` is `true`. `nil` otherwise.
+- parameter error: The error if `success` is `false`. `nil` otherwise.
+*/
+public typealias LocationUpdateResponseHandler = (success: Bool, location: CLLocation?, error: NSError?) -> Void
+
+public struct LocationUpdateRequest {
+    let accuracy: LocationAccuracy
+    let updateFrequency: LocationUpdateFrequency
+    let response: LocationUpdateResponseHandler
+
+    /**
+     Initializes a request to be used for registering for location updates.
+
+     - parameter accuracy: The accuracy desired by the listener. Since there can be multiple listeners, the framework endeavors to provide the highest level of accuracy registered. Default value is `.Good`
+     - parameter updateFrequency: The rate at which to notify the listener. Default value is `.Continuous`.
+     - parameter response: This closure is called when a update is received or if there's an error.
+     */
+    public init(accuracy: LocationAccuracy = .Good, updateFrequency: LocationUpdateFrequency = .ChangesOnly, response: LocationUpdateResponseHandler) {
+        self.accuracy = accuracy
+        self.response = response
+        self.updateFrequency = updateFrequency
+    }
+}

--- a/ELLocation/LocationUpdateService.swift
+++ b/ELLocation/LocationUpdateService.swift
@@ -1,0 +1,47 @@
+//
+//  LocationUpdateService.swift
+//  ELLocation
+//
+//  Created by Alex Johnson on 3/16/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+// A protocol for a type that wants to provide location updates.
+public protocol LocationUpdateProvider {
+    func registerListener(listener: AnyObject, request: LocationUpdateRequest) -> NSError?
+    func deregisterListener(listener: AnyObject)
+}
+
+// The interface for requesting location updates. Listeners can register to be informed of location updates
+// They can request to be deregistered or will be deregistered automatically when they are dealloced.
+public struct LocationUpdateService: LocationUpdateProvider {
+    let locationProvider: LocationUpdateProvider
+
+    /**
+     Registers a listener to receive location updates as per the parameters defined in the request.
+
+     - parameter listener: The listener to register.
+     - parameter request: The parameters of the request.
+     - returns: An optional error that could happen when registering. See `ELLocationError`.
+     */
+    public func registerListener(listener: AnyObject, request: LocationUpdateRequest) -> NSError? {
+        return locationProvider.registerListener(listener, request: request)
+    }
+
+    /**
+     Deregisters a listener from receiving any more location updates.
+
+     - parameter listener: The listener to deregister.
+     */
+    public func deregisterListener(listener: AnyObject) {
+        locationProvider.deregisterListener(listener)
+    }
+
+    public init() {
+        self.init(locationProvider: LocationManager.shared)
+    }
+
+    init(locationProvider: LocationUpdateProvider) {
+        self.locationProvider = locationProvider
+    }
+}


### PR DESCRIPTION
#### What does this PR do?

Just what it says on the tin: splits `LocationService.swift` into several separate files; one for each top-level type.
#### Any background context you want to provide?

In the time since it was created, this file has grown pretty large and difficult to navigate. Splitting it into separate files will make the module easier to work with.
#### Where should the reviewer start?

The only change I made other than simply cutting and pasting into the separate files was to change `LocationManager.shared` from `private` to `internal` since cross-file access is needed.
#### How should this be manually tested?
- Run the unit tests.
- Run the example app.
