### PR TITLE
Update location error domain

### DIFF
--- a/ELLocation/ELLocationError.swift
+++ b/ELLocation/ELLocationError.swift
@@ -8,7 +8,7 @@
 
 import ELFoundation
 
-let ELLocationErrorDomain: String = "ELLocationErrorDomain"
+public let ELLocationErrorDomain = "ELLocationErrorDomain"
 
 public enum ELLocationError: Int, NSErrorEnum {
     /// The user has denied access to location services or their device has been configured to restrict it.
@@ -21,7 +21,7 @@ public enum ELLocationError: Int, NSErrorEnum {
     case LocationServicesDisabled
 
     public var domain: String {
-        return "io.theholygrail.ELLocationError"
+        return ELLocationErrorDomain
     }
 
     public var errorDescription: String {

--- a/ELLocationExample/AppDelegate.swift
+++ b/ELLocationExample/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         if let requestAuthError = LocationAuthorizationService().requestAuthorization(.WhenInUse) {
             //TODO: Client needs to process error and re-request auth
+            assert(requestAuthError.domain == ELLocationErrorDomain, "request authorization returned error with unexpected domain '\(requestAuthError.domain)'")
             print("REQUEST AUTH: error requesting authorization. error is \(requestAuthError.localizedDescription)")
         } else {
             startLocationUpdates()


### PR DESCRIPTION
#### What does this PR do?

Tiny PR to change the `domain` for `ELLocationError` to use `ELLocationErrorDomain`.
#### Any background context you want to provide?

I'm speculating here… `ELLocationError` currently uses `io.theholygrail.ELLocationError` for its `domain`, and there is a constant named `ELLocationErrorDomain` in the same file that's not being used for anything. It seems like maybe it's supposed to be used like this?

I also made `ELLocationErrorDomain` public so that code that uses the module can compare error domains to it. And I added an `assert()` call in the example app.
