### PR TITLE
Replace existing request when re-adding listener

### DIFF
--- a/ELLocation/LocationManager.swift
+++ b/ELLocation/LocationManager.swift
@@ -266,7 +266,9 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         let locationListener = LocationListener(listener: listener, request: request)
 
         synchronized(self) {
-            self.allLocationListeners.append(locationListener)
+            unsafeRemoveListener(listener)
+
+            allLocationListeners.append(locationListener)
         }
 
         updateLocationMonitoring()
@@ -276,15 +278,26 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
 
     func deregisterListener(listener: AnyObject) {
         synchronized(self) {
-            for (index, locationListener) in self.allLocationListeners.enumerate() {
-                if locationListener.listener === listener {
-                    self.allLocationListeners.removeAtIndex(index)
-                    break
-                }
-            }
+            unsafeRemoveListener(listener)
         }
 
         updateLocationMonitoring()
+    }
+
+    /**
+     Removes the (only) entry for listener from `allLocationListeners`, if one exists.
+
+     **This method is not threadsafe.** It may only safely be called from inside a `synchronized(self)` block.
+     */
+    private func unsafeRemoveListener(listener: AnyObject) {
+        let locationListeners = allLocationListeners
+
+        for (index, locationListener) in locationListeners.enumerate() {
+            if locationListener.listener === listener {
+                allLocationListeners.removeAtIndex(index)
+                break
+            }
+        }
     }
 
     // MARK: LocationAuthorizationProvider

--- a/ELLocation/LocationUpdateService.swift
+++ b/ELLocation/LocationUpdateService.swift
@@ -19,6 +19,9 @@ public struct LocationUpdateService: LocationUpdateProvider {
 
     /**
      Registers a listener to receive location updates as per the parameters defined in the request.
+     
+     A listener may only be registered with one request at a time. If a listener is registered more than once,
+     previously-registered requests will be discarded.
 
      - parameter listener: The listener to register.
      - parameter request: The parameters of the request.

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -107,6 +107,31 @@ extension LocationUpdateService {
     }
 }
 
+// Private extensions to access all enum cases:
+
+private extension CLAuthorizationStatus {
+    static var allCases: [CLAuthorizationStatus] {
+        return [.NotDetermined, .Denied, .Restricted, .AuthorizedWhenInUse, .AuthorizedAlways]
+    }
+}
+
+private extension LocationAccuracy {
+    static var allCases: [LocationAccuracy] {
+        return [.Coarse, .Good, .Better, .Best]
+    }
+}
+
+private extension LocationAuthorization {
+    static var allCases: [LocationAuthorization] {
+        return [.WhenInUse, .Always]
+    }
+}
+private extension LocationUpdateFrequency {
+    static var allCases: [LocationUpdateFrequency] {
+        return [.ChangesOnly, .Continuous]
+    }
+}
+
 class ELLocationTests: XCTestCase {
     
     override func setUp() {
@@ -248,8 +273,8 @@ class ELLocationTests: XCTestCase {
 
     func testRequestAuth() {
         for servicesEnabled in [true, false] {
-            for authorizationStatus: CLAuthorizationStatus in [.NotDetermined, .Denied, .Restricted, .AuthorizedWhenInUse, .AuthorizedAlways] {
-                for authorization: LocationAuthorization in [.WhenInUse, .Always] {
+            for authorizationStatus: CLAuthorizationStatus in CLAuthorizationStatus.allCases {
+                for authorization: LocationAuthorization in LocationAuthorization.allCases {
                     for whenInUseMsg: String? in [nil, "When in use, please!"] {
                         for alwaysMsg: String? in [nil, "Always, please!"] {
                             testRequestAuth(servicesEnabled: servicesEnabled, authorizationStatus: authorizationStatus,
@@ -318,9 +343,9 @@ class ELLocationTests: XCTestCase {
         // Monitoring is dependent on the authorization status, accuracy and update frequency. These nested for loops
         // allow the test to cover all possible combinations.
 
-        for authorizationStatus: CLAuthorizationStatus in [.NotDetermined, .Denied, .Restricted, .AuthorizedWhenInUse, .AuthorizedAlways] {
-            for accuracy: LocationAccuracy in [.Coarse, .Good, .Better, .Best] {
-                for updateFrequency: LocationUpdateFrequency in [.ChangesOnly, .Continuous] {
+        for authorizationStatus: CLAuthorizationStatus in CLAuthorizationStatus.allCases {
+            for accuracy: LocationAccuracy in LocationAccuracy.allCases {
+                for updateFrequency: LocationUpdateFrequency in LocationUpdateFrequency.allCases {
                     testLocationMonitoring(authorizationStatus: authorizationStatus, accuracy: accuracy, updateFrequency: updateFrequency)
                 }
             }
@@ -398,7 +423,7 @@ class ELLocationTests: XCTestCase {
     // MARK: Distance filter
 
     func testContinuousUpdatesDisablesDistanceFilter() {
-        for accuracy: LocationAccuracy in [.Coarse, .Good, .Better, .Best] {
+        for accuracy: LocationAccuracy in LocationAccuracy.allCases {
             let manager = MockCLLocationManager()
             let provider = LocationManager(manager: manager)
             let subject = LocationUpdateService(locationProvider: provider)
@@ -490,7 +515,7 @@ class ELLocationTests: XCTestCase {
     // MARK: Accuracy in practice
 
     func testContinuousUpdates() {
-        for accuracy: LocationAccuracy in [.Coarse, .Good, .Better, .Best] {
+        for accuracy: LocationAccuracy in LocationAccuracy.allCases {
             let done = expectationWithDescription("\(accuracy) test finished")
 
             testContinuousUpdates(accuracy, then: done.fulfill)

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -13,7 +13,7 @@ import CoreLocation
 
 class MockCLLocationManager: ELCLLocationManager {
     var coreLocationServicesEnabled: Bool = true
-    var coreLocationAuthorizationStatus: CLAuthorizationStatus = .NotDetermined
+    var coreLocationAuthorizationStatus: CLAuthorizationStatus = .AuthorizedWhenInUse
     var alwaysUsageDescription: String? = "Access to your location at all times is required!"
     var whenInUseUsageDescription: String? = "Access to your location while using the app is required!"
     var requestedAuthorization: LocationAuthorization? = nil
@@ -403,21 +403,19 @@ class ELLocationTests: XCTestCase {
         let provider = LocationManager(manager: manager)
         let subject = LocationUpdateService(locationProvider: provider)
 
-        manager.withMockAuthorizationStatus(.AuthorizedWhenInUse) {
-            XCTAssertFalse(manager.updatingLocation, "Before adding listeners, location is not updating (GPS)")
+        XCTAssertFalse(manager.updatingLocation, "Before adding listeners, location is not updating (GPS)")
+
+        subject.withMockListener(accuracy: .Good, updateFrequency: .Continuous) {
+            XCTAssertTrue(manager.updatingLocation, "Adding a listener initiates location updates")
 
             subject.withMockListener(accuracy: .Good, updateFrequency: .Continuous) {
-                XCTAssertTrue(manager.updatingLocation, "Adding a listener initiates location updates")
-
-                subject.withMockListener(accuracy: .Good, updateFrequency: .Continuous) {
-                    XCTAssertTrue(manager.updatingLocation, "Adding a second listener continues location updates")
-                }
-
-                XCTAssertTrue(manager.updatingLocation, "Removing second listener does not stop location updates")
+                XCTAssertTrue(manager.updatingLocation, "Adding a second listener continues location updates")
             }
 
-            XCTAssertFalse(manager.updatingLocation, "Removing all listeners stop location updates")
+            XCTAssertTrue(manager.updatingLocation, "Removing second listener does not stop location updates")
         }
+
+        XCTAssertFalse(manager.updatingLocation, "Removing all listeners stop location updates")
     }
     
     // MARK: Distance filter

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -145,10 +145,10 @@ class ELLocationTests: XCTestCase {
     }
     
     func testCalculateAndUpdateAccuracyCrash() {
-        LocationAuthorizationService().requestAuthorization(.WhenInUse)
-        LocationAuthorizationService().requestAuthorization(.Always)
-        
         let subject = LocationManager()
+
+        LocationAuthorizationService(locationAuthorizationProvider: subject).requestAuthorization(.WhenInUse)
+        LocationAuthorizationService(locationAuthorizationProvider: subject).requestAuthorization(.Always)
 
         // no crash here is a test success
         subject.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: 42, longitude: 42)])


### PR DESCRIPTION
#### What does this PR do?

Updates the `LocationManager` to clarify the behavior when `registerListener()` is called more than once with the same listener.
#### Any background context you want to provide?

The old behavior was undocumented, and pretty strange. The requests from both calls would remain active and receive location updates. After that, each call to `deregisterListener()` would remove the least-recently-added request for that listener.

There are a few possibilities for addressing this, some of which are:
- Keep all requests and allow `deregister()` to remove all of them.
- Keep all requests and update `deregister()` to take a `request` to select the one to remove.
- Return an error when adding a listener that already exists.
- Silently ignore the new request.
- Silently drop the old request.
- Drop the old request, but deliver an error to its response handler.

I chose to silently drop the old request because that make the module easier for my code to use. I'm open to discussion about other ways to go.

As one data point: In my usage, I need to periodically change the type of location updates I receive. I do this by registering my listener with a new request. I _could_ unregister my listener first and then register it with the new request. But, removing the listener shuts off location tracking, and then re-adding it turns tracking back on. This seems wasteful, and potentially buggy, so I'd prefer to be able to "replace" my location request instead. Rather than a separate `replaceListener()` method, I chose to just make `registerListener()` act that way.
#### Where should the reviewer start?

I did a little maintenance of the tests (549d2b7, 9a4a7ae, 0812aa9). The actual change is in 5b40709. Basically, I just updated `registerListener()` to look for, and remove, an existing entry for the listener before adding it.
#### How should this be manually tested?

I added a test, `testAddListenerMoreThanOnce`, that fails with the current behavior and passes with the new behavior.
