### PR TITLE
Request authorization tweaks

### DIFF
--- a/ELLocation/ELLocationError.swift
+++ b/ELLocation/ELLocationError.swift
@@ -11,8 +11,10 @@ import ELFoundation
 public let ELLocationErrorDomain = "ELLocationErrorDomain"
 
 public enum ELLocationError: Int, NSErrorEnum {
-    /// The user has denied access to location services or their device has been configured to restrict it.
-    case AuthorizationDeniedOrRestricted
+    /// The user has denied access to location services.
+    case AuthorizationRestricted
+    /// The user's device has been configured to restrict access to location services.
+    case AuthorizationDenied
     /// The callers is asking for authorization, but the corresponding description is missing from Info.plist
     case UsageDescriptionMissing
     /// The caller is asking for authorization 'always' but user has granted 'when in use'.
@@ -26,8 +28,10 @@ public enum ELLocationError: Int, NSErrorEnum {
 
     public var errorDescription: String {
         switch self {
-        case .AuthorizationDeniedOrRestricted:
-            return "The user has denied location services in Settings or has been restricted from using them."
+        case .AuthorizationRestricted:
+            return "The user has denied location services in Settings."
+        case .AuthorizationDenied:
+            return "The user has been restricted from using location services."
         case .UsageDescriptionMissing:
             return "No description for the requested usage authorization has been provided in the app."
         case .AuthorizationWhenInUse:

--- a/ELLocation/ELLocationError.swift
+++ b/ELLocation/ELLocationError.swift
@@ -11,9 +11,9 @@ import ELFoundation
 public let ELLocationErrorDomain = "ELLocationErrorDomain"
 
 public enum ELLocationError: Int, NSErrorEnum {
-    /// The user has denied access to location services.
-    case AuthorizationRestricted
     /// The user's device has been configured to restrict access to location services.
+    case AuthorizationRestricted
+    /// The user has denied access to location services.
     case AuthorizationDenied
     /// The callers is asking for authorization, but the corresponding description is missing from Info.plist
     case UsageDescriptionMissing
@@ -29,9 +29,9 @@ public enum ELLocationError: Int, NSErrorEnum {
     public var errorDescription: String {
         switch self {
         case .AuthorizationRestricted:
-            return "The user has denied location services in Settings."
-        case .AuthorizationDenied:
             return "The user has been restricted from using location services."
+        case .AuthorizationDenied:
+            return "The user has denied location services in Settings."
         case .UsageDescriptionMissing:
             return "No description for the requested usage authorization has been provided in the app."
         case .AuthorizationWhenInUse:

--- a/ELLocation/LocationManager.swift
+++ b/ELLocation/LocationManager.swift
@@ -331,8 +331,10 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         var requestAuth = false
 
         switch authorizationStatus {
-        case .Denied, .Restricted:
-            return NSError(ELLocationError.AuthorizationDeniedOrRestricted)
+        case .Denied:
+            return NSError(ELLocationError.AuthorizationDenied)
+        case .Restricted:
+            return NSError(ELLocationError.AuthorizationRestricted)
         case .NotDetermined:
             requestAuth = true
         case .AuthorizedAlways:

--- a/ELLocation/LocationManager.swift
+++ b/ELLocation/LocationManager.swift
@@ -294,6 +294,40 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             return locationServicesError
         }
 
+        // Note: According to Apple's documentation, requesting authorization *only* works if the current status
+        // is not determined. In practice, that is not entirely true. If When-In-Use authorization was previously
+        // requested--and granted--the app may still request Always authorization (once). However, if the user
+        // choses not to allow When-In-Use authorization, or manually changes location authorization to "never"
+        // in their Settings, then the app loses this ability to request Always authorization.
+        //
+        // Example 1:
+        //
+        // 1. App requests `.WhenInUse` authorization.
+        // 2. iOS shows "Allow Access When in Use" alert.
+        // 3. User taps "Allow".
+        // 4. App requests `.Always` authorization.
+        // 5. iOS shows "Allow Access Always" alert.
+        //
+        // Example 2:
+        //
+        // 1. App requests `.WhenInUse` authorization.
+        // 2. iOS shows "Allow Access When in Use" alert.
+        // 3. User taps "Allow".
+        // 4. User opens Settings and changes location access to "Never".
+        // 5. App requests `.Always` authorization.
+        // 6. **Nothing happens**
+        //
+        // Example 3:
+        //
+        // 1. App requests `.WhenInUse` authorization.
+        // 2. iOS shows "Allow Access When in Use" alert.
+        // 3. User taps "Don't Allow".
+        // 4. App requests `.Always` authorization.
+        // 5. **Nothing happens**
+        //
+        // Because of how finicky this is, and that it goes contrary to the documentation, this code returns an
+        // error if "always" authorization is requested and the current authorization status is "when in use".
+
         var requestAuth = false
 
         switch authorizationStatus {


### PR DESCRIPTION
#### What does this PR do?

Some small tweaks and updates to the request authorization code.
#### Any background context you want to provide?

6fddbdc: I discovered a strange edge case related to requesting authorization, so I added a big comment describing it. Here's a (quoted) copy of that text:

> Note: According to Apple's documentation, requesting authorization _only_ works if the current status is not determined. In practice, that is not entirely true. If When-In-Use authorization was previously requested--and granted--the app may still request Always authorization (once). However, if the user choses not to allow When-In-Use authorization, or manually changes location authorization to "never" in their Settings, then the app loses this ability to request Always authorization.
> 
> Example 1:
> 1. App requests `.WhenInUse` authorization.
> 2. iOS shows "Allow Access When in Use" alert.
> 3. User taps "Allow".
> 4. App requests `.Always` authorization.
> 5. iOS shows "Allow Access Always" alert.
> 
> Example 2:
> 1. App requests `.WhenInUse` authorization.
> 2. iOS shows "Allow Access When in Use" alert.
> 3. User taps "Allow".
> 4. User opens Settings and changes location access to "Never".
> 5. App requests `.Always` authorization.
> 6. **Nothing happens**
> 
> Example 3:
> 1. App requests `.WhenInUse` authorization.
> 2. iOS shows "Allow Access When in Use" alert.
> 3. User taps "Don't Allow".
> 4. App requests `.Always` authorization.
> 5. **Nothing happens**
> 
> Because of how finicky this is, and that it goes contrary to the documentation, this code returns an error if "always" authorization is requested and the current authorization status is "when in use".

0fc2531: Also, I created separate errors for location authorization being denied vs restricted. The steps the user needs to follow to reenable location services in these two cases are quite different, so it makes sense to have separate errors.

5c4b31d: Finally, I redesigned the code that actually requests the authorization so that there's just a single set of cases covering the different combinations of authorization status and requested authorization.
