### PR TITLE
Add annotations to generate warnings for unhandled errors

### DIFF
--- a/ELLocation/LocationAuthorizationService.swift
+++ b/ELLocation/LocationAuthorizationService.swift
@@ -21,6 +21,7 @@ public struct LocationAuthorizationService: LocationAuthorizationProvider {
      - parameter authorization: The authorization being requested.
      - returns: An optional error that could happen when requesting authorization. See `ELLocationError`.
      */
+    @warn_unused_result
     public func requestAuthorization(authorization: LocationAuthorization) -> NSError? {
         return locationAuthorizationProvider.requestAuthorization(authorization)
     }

--- a/ELLocation/LocationUpdateService.swift
+++ b/ELLocation/LocationUpdateService.swift
@@ -27,6 +27,7 @@ public struct LocationUpdateService: LocationUpdateProvider {
      - parameter request: The parameters of the request.
      - returns: An optional error that could happen when registering. See `ELLocationError`.
      */
+    @warn_unused_result
     public func registerListener(listener: AnyObject, request: LocationUpdateRequest) -> NSError? {
         return locationProvider.registerListener(listener, request: request)
     }

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -178,7 +178,8 @@ class ELLocationTests: XCTestCase {
         }
 
         // Add listener:
-        subject.registerListener(listener, request:request)
+        let error = subject.registerListener(listener, request:request)
+        XCTAssertNil(error)
         
         // Update location:
         manager.mockMoveByAtLeast(5)
@@ -292,7 +293,8 @@ class ELLocationTests: XCTestCase {
         }
 
         // Add listener:
-        subject.registerListener(listener!, request:request)
+        let error = subject.registerListener(listener!, request:request)
+        XCTAssertNil(error)
 
         // Update location:
         manager.mockMoveByAtLeast(5)
@@ -502,16 +504,20 @@ class ELLocationTests: XCTestCase {
 
         // Add listeners from lowest to highest accuracy and verify that distance filter decreases:
 
-        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { _,_,_ in })
+        let error1 = subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { _,_,_ in })
+        XCTAssertNil(error1)
         XCTAssertEqual(manager.distanceFilter, 500)
 
-        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { _,_,_ in })
+        let error2 = subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { _,_,_ in })
+        XCTAssertNil(error2)
         XCTAssertEqual(manager.distanceFilter, 50)
 
-        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { _,_,_ in })
+        let error3 = subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { _,_,_ in })
+        XCTAssertNil(error3)
         XCTAssertEqual(manager.distanceFilter, 5)
 
-        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { _,_,_ in })
+        let error4 = subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { _,_,_ in })
+        XCTAssertNil(error4)
         XCTAssertEqual(manager.distanceFilter, 2)
 
         // Remove listeners from lowest to highest accuracy and verify that distance filter DOES NOT CHANGE:
@@ -542,16 +548,20 @@ class ELLocationTests: XCTestCase {
 
         // Add listeners from lowest to highest accuracy and verify that desired accuracy increases:
 
-        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { (_,_,_) -> Void in })
+        let error1 = subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { (_,_,_) -> Void in })
+        XCTAssertNil(error1)
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyKilometer)
 
-        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { (_,_,_) -> Void in })
+        let error2 = subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { (_,_,_) -> Void in })
+        XCTAssertNil(error2)
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyHundredMeters)
 
-        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { (_,_,_) -> Void in })
+        let error3 = subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { (_,_,_) -> Void in })
+        XCTAssertNil(error3)
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyNearestTenMeters)
 
-        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { (_,_,_) -> Void in })
+        let error4 = subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { (_,_,_) -> Void in })
+        XCTAssertNil(error4)
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyBest)
 
         // Remove listeners from lowest to highest accuracy and verify that desired accuracy DOES NOT CHANGE:
@@ -590,7 +600,8 @@ class ELLocationTests: XCTestCase {
         }
 
         // Add listener:
-        subject.registerListener(listener, request:request)
+        let error = subject.registerListener(listener, request:request)
+        XCTAssertNil(error)
 
         // Update location:
         manager.mockMoveByAtLeast(0.1)
@@ -644,7 +655,8 @@ class ELLocationTests: XCTestCase {
         }
 
         // Add listener:
-        subject.registerListener(listener, request: request)
+        let error = subject.registerListener(listener, request:request)
+        XCTAssertNil(error)
 
         // Update location:
         manager.mockMoveByAtLeast(0.001)
@@ -704,7 +716,8 @@ class ELLocationTests: XCTestCase {
         }
 
         // Add listener:
-        subject.registerListener(listener, request: request)
+        let error = subject.registerListener(listener, request:request)
+        XCTAssertNil(error)
 
         // Update location:
         manager.mockMoveByAtLeast(threshold)

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -143,16 +143,6 @@ class ELLocationTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
-    func testCalculateAndUpdateAccuracyCrash() {
-        let subject = LocationManager()
-
-        LocationAuthorizationService(locationAuthorizationProvider: subject).requestAuthorization(.WhenInUse)
-        LocationAuthorizationService(locationAuthorizationProvider: subject).requestAuthorization(.Always)
-
-        // no crash here is a test success
-        subject.locationManager(CLLocationManager(), didUpdateLocations: [CLLocation(latitude: 42, longitude: 42)])
-    }
 
     // MARK: Listeners
     

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -552,16 +552,16 @@ class ELLocationTests: XCTestCase {
 
         // Add listeners from lowest to highest accuracy and verify that desired accuracy increases:
 
-        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { (success, location, error) -> Void in })
+        subject.registerListener(coarseListener, request: LocationUpdateRequest(accuracy: .Coarse) { (_,_,_) -> Void in })
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyKilometer)
 
-        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { (success, location, error) -> Void in })
+        subject.registerListener(goodListener, request: LocationUpdateRequest(accuracy: .Good) { (_,_,_) -> Void in })
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyHundredMeters)
 
-        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { (success, location, error) -> Void in })
+        subject.registerListener(betterListener, request: LocationUpdateRequest(accuracy: .Better) { (_,_,_) -> Void in })
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyNearestTenMeters)
 
-        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { (success, location, error) -> Void in })
+        subject.registerListener(bestListener, request: LocationUpdateRequest(accuracy: .Best) { (_,_,_) -> Void in })
         XCTAssertEqual(manager.desiredAccuracy, kCLLocationAccuracyBest)
 
         // Remove listeners from lowest to highest accuracy and verify that desired accuracy DOES NOT CHANGE:

--- a/ELLocationTests/ELLocationTests.swift
+++ b/ELLocationTests/ELLocationTests.swift
@@ -208,7 +208,7 @@ class ELLocationTests: XCTestCase {
             }
         }
         
-        waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
+        waitForExpectationsWithTimeout(5) { _ in }
     }
 
     func testAddListenerMoreThanOnce() {
@@ -274,7 +274,7 @@ class ELLocationTests: XCTestCase {
             }
         }
 
-        waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
+        waitForExpectationsWithTimeout(5) { _ in }
     }
 
     func testWeakListenerRefs() {
@@ -324,7 +324,7 @@ class ELLocationTests: XCTestCase {
             }
         }
 
-        waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
+        waitForExpectationsWithTimeout(5) { _ in }
     }
     
     // MARK: Request authorization
@@ -585,7 +585,7 @@ class ELLocationTests: XCTestCase {
             testContinuousUpdates(accuracy, then: done.fulfill)
         }
 
-        waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
+        waitForExpectationsWithTimeout(5) { _ in }
     }
 
     func testContinuousUpdates(accuracy: LocationAccuracy, then done: () -> Void) {
@@ -640,7 +640,7 @@ class ELLocationTests: XCTestCase {
             testDiscreteUpdates(accuracy, threshold: threshold, then: done.fulfill)
         }
 
-        waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
+        waitForExpectationsWithTimeout(5) { _ in }
     }
 
     func testDiscreteUpdates(accuracy: LocationAccuracy, threshold: CLLocationDistance, then done: () -> Void) {
@@ -739,6 +739,6 @@ class ELLocationTests: XCTestCase {
             }
         }
         
-        waitForExpectationsWithTimeout(0.1) { (error: NSError?) -> Void in }
+        waitForExpectationsWithTimeout(5) { _ in }
     }
 }


### PR DESCRIPTION
#### What does this PR do?

Adds `@warn_unused_result` annotations to methods that can return errors to prevent those errors from going silently unhandled.
#### Any background context you want to provide?

I think I would prefer it if these errors were thrown, rather than returned. In that case, it would be impossible to accidentally ignore the errors. But, warnings for unused results are an OK substitute.
#### Where should the reviewer start?

I added the annotations to `registerListener()` and `requestAuthorization()` and updated the tests to assert that no errors are generated.

Also, I removed the `testCalculateAndUpdateAccuracyCrash` since it was actually receiving errors from the `registerListener()` calls and silently failing. I don't think this test was actually doing any good anymore.
#### How should this be manually tested?

Just run the tests :smile:.
