### PR TITLE
Throw errors instead of returning them

### DIFF
--- a/ELLocation/ELLocationError.swift
+++ b/ELLocation/ELLocationError.swift
@@ -8,9 +8,7 @@
 
 import ELFoundation
 
-public let ELLocationErrorDomain = "ELLocationErrorDomain"
-
-public enum ELLocationError: Int, NSErrorEnum {
+public enum ELLocationError: ErrorType {
     /// The user's device has been configured to restrict access to location services.
     case AuthorizationRestricted
     /// The user has denied access to location services.
@@ -21,10 +19,6 @@ public enum ELLocationError: Int, NSErrorEnum {
     case AuthorizationWhenInUse
     /// Location services are disabled.
     case LocationServicesDisabled
-
-    public var domain: String {
-        return ELLocationErrorDomain
-    }
 
     public var errorDescription: String {
         switch self {

--- a/ELLocation/LocationAuthorizationService.swift
+++ b/ELLocation/LocationAuthorizationService.swift
@@ -8,7 +8,7 @@
 
 // A protocol for a type that wants to provide location authorization.
 public protocol LocationAuthorizationProvider {
-    func requestAuthorization(authorization: LocationAuthorization) -> NSError?
+    func requestAuthorization(authorization: LocationAuthorization) throws
 }
 
 // The interface for requesting location authorization
@@ -21,9 +21,8 @@ public struct LocationAuthorizationService: LocationAuthorizationProvider {
      - parameter authorization: The authorization being requested.
      - returns: An optional error that could happen when requesting authorization. See `ELLocationError`.
      */
-    @warn_unused_result
-    public func requestAuthorization(authorization: LocationAuthorization) -> NSError? {
-        return locationAuthorizationProvider.requestAuthorization(authorization)
+    public func requestAuthorization(authorization: LocationAuthorization) throws {
+        try locationAuthorizationProvider.requestAuthorization(authorization)
     }
 
     public init() {

--- a/ELLocation/LocationAuthorizationService.swift
+++ b/ELLocation/LocationAuthorizationService.swift
@@ -19,7 +19,8 @@ public struct LocationAuthorizationService: LocationAuthorizationProvider {
      Request the specified authorization.
 
      - parameter authorization: The authorization being requested.
-     - returns: An optional error that could happen when requesting authorization. See `ELLocationError`.
+     - throws: `ELLocationError` if the authorization request is not possible. Note that an error
+               is **not** thrown by this method if the user _declines_ to authorize access.
      */
     public func requestAuthorization(authorization: LocationAuthorization) throws {
         try locationAuthorizationProvider.requestAuthorization(authorization)

--- a/ELLocation/LocationManager.swift
+++ b/ELLocation/LocationManager.swift
@@ -260,7 +260,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
 
     func registerListener(listener: AnyObject, request: LocationUpdateRequest) throws {
         guard manager.coreLocationServicesEnabled else {
-            throw NSError(ELLocationError.LocationServicesDisabled)
+            throw ELLocationError.LocationServicesDisabled
         }
 
         let locationListener = LocationListener(listener: listener, request: request)
@@ -302,7 +302,7 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
 
     func requestAuthorization(authorization: LocationAuthorization) throws {
         guard manager.coreLocationServicesEnabled else {
-            throw NSError(ELLocationError.LocationServicesDisabled)
+            throw ELLocationError.LocationServicesDisabled
         }
 
         // Note: According to Apple's documentation, requesting authorization *only* works if the current status
@@ -342,23 +342,23 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         switch (authorizationStatus, authorization) {
 
         case (.Denied, _):
-            throw NSError(ELLocationError.AuthorizationDenied)
+            throw ELLocationError.AuthorizationDenied
 
         case (.Restricted, _):
-            throw NSError(ELLocationError.AuthorizationRestricted)
+            throw ELLocationError.AuthorizationRestricted
 
         case (.AuthorizedWhenInUse, .Always):
-            throw NSError(ELLocationError.AuthorizationWhenInUse)
+            throw ELLocationError.AuthorizationWhenInUse
 
         case (.NotDetermined, .WhenInUse):
             if manager.whenInUseUsageDescription == nil {
-                throw NSError(ELLocationError.UsageDescriptionMissing)
+                throw ELLocationError.UsageDescriptionMissing
             }
             manager.requestWhenInUseAuthorization()
 
         case (.NotDetermined, .Always):
             if manager.alwaysUsageDescription == nil {
-                throw NSError(ELLocationError.UsageDescriptionMissing)
+                throw ELLocationError.UsageDescriptionMissing
             }
             manager.requestAlwaysAuthorization()
 

--- a/ELLocation/LocationManager.swift
+++ b/ELLocation/LocationManager.swift
@@ -258,9 +258,9 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
 
     // MARK: LocationUpdateProvider
 
-    func registerListener(listener: AnyObject, request: LocationUpdateRequest) -> NSError? {
-        if let locationServicesError = checkIfLocationServicesEnabled() {
-            return locationServicesError
+    func registerListener(listener: AnyObject, request: LocationUpdateRequest) throws {
+        guard manager.coreLocationServicesEnabled else {
+            throw NSError(ELLocationError.LocationServicesDisabled)
         }
 
         let locationListener = LocationListener(listener: listener, request: request)
@@ -272,8 +272,6 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         }
 
         updateLocationMonitoring()
-
-        return nil
     }
 
     func deregisterListener(listener: AnyObject) {
@@ -302,9 +300,9 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
 
     // MARK: LocationAuthorizationProvider
 
-    func requestAuthorization(authorization: LocationAuthorization) -> NSError? {
-        if let locationServicesError = checkIfLocationServicesEnabled() {
-            return locationServicesError
+    func requestAuthorization(authorization: LocationAuthorization) throws {
+        guard manager.coreLocationServicesEnabled else {
+            throw NSError(ELLocationError.LocationServicesDisabled)
         }
 
         // Note: According to Apple's documentation, requesting authorization *only* works if the current status
@@ -344,23 +342,23 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
         switch (authorizationStatus, authorization) {
 
         case (.Denied, _):
-            return NSError(ELLocationError.AuthorizationDenied)
+            throw NSError(ELLocationError.AuthorizationDenied)
 
         case (.Restricted, _):
-            return NSError(ELLocationError.AuthorizationRestricted)
+            throw NSError(ELLocationError.AuthorizationRestricted)
 
         case (.AuthorizedWhenInUse, .Always):
-            return NSError(ELLocationError.AuthorizationWhenInUse)
+            throw NSError(ELLocationError.AuthorizationWhenInUse)
 
         case (.NotDetermined, .WhenInUse):
             if manager.whenInUseUsageDescription == nil {
-                return NSError(ELLocationError.UsageDescriptionMissing)
+                throw NSError(ELLocationError.UsageDescriptionMissing)
             }
             manager.requestWhenInUseAuthorization()
 
         case (.NotDetermined, .Always):
             if manager.alwaysUsageDescription == nil {
-                return NSError(ELLocationError.UsageDescriptionMissing)
+                throw NSError(ELLocationError.UsageDescriptionMissing)
             }
             manager.requestAlwaysAuthorization()
 
@@ -368,8 +366,6 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
             // We already have the desired authorization (or higher).
             break
         }
-
-        return nil
     }
 
     // MARK: Internal Interface
@@ -396,14 +392,6 @@ class LocationManager: NSObject, LocationUpdateProvider, LocationAuthorizationPr
                 manager.stopUpdatingLocation()
                 manager.stopMonitoringSignificantLocationChanges()
             }
-        }
-    }
-
-    private func checkIfLocationServicesEnabled() -> NSError? {
-        if manager.coreLocationServicesEnabled {
-            return nil
-        } else {
-            return NSError(ELLocationError.LocationServicesDisabled)
         }
     }
 

--- a/ELLocation/LocationUpdateService.swift
+++ b/ELLocation/LocationUpdateService.swift
@@ -25,7 +25,7 @@ public struct LocationUpdateService: LocationUpdateProvider {
 
      - parameter listener: The listener to register.
      - parameter request: The parameters of the request.
-     - returns: An optional error that could happen when registering. See `ELLocationError`.
+     - throws: `ELLocationError.LocationServicesDisabled` if location services are disabled on the device.
      */
     public func registerListener(listener: AnyObject, request: LocationUpdateRequest) throws {
         try locationProvider.registerListener(listener, request: request)

--- a/ELLocation/LocationUpdateService.swift
+++ b/ELLocation/LocationUpdateService.swift
@@ -8,7 +8,7 @@
 
 // A protocol for a type that wants to provide location updates.
 public protocol LocationUpdateProvider {
-    func registerListener(listener: AnyObject, request: LocationUpdateRequest) -> NSError?
+    func registerListener(listener: AnyObject, request: LocationUpdateRequest) throws
     func deregisterListener(listener: AnyObject)
 }
 
@@ -27,9 +27,8 @@ public struct LocationUpdateService: LocationUpdateProvider {
      - parameter request: The parameters of the request.
      - returns: An optional error that could happen when registering. See `ELLocationError`.
      */
-    @warn_unused_result
-    public func registerListener(listener: AnyObject, request: LocationUpdateRequest) -> NSError? {
-        return locationProvider.registerListener(listener, request: request)
+    public func registerListener(listener: AnyObject, request: LocationUpdateRequest) throws {
+        try locationProvider.registerListener(listener, request: request)
     }
 
     /**

--- a/ELLocationExample/AppDelegate.swift
+++ b/ELLocationExample/AppDelegate.swift
@@ -24,7 +24,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func requestLocationAuthorization() {
-        if let requestAuthError = LocationAuthorizationService().requestAuthorization(.WhenInUse) {
+        do {
+            try LocationAuthorizationService().requestAuthorization(.WhenInUse)
+        } catch let requestAuthError as NSError {
             //TODO: Client needs to process error and re-request auth
             assert(requestAuthError.domain == ELLocationErrorDomain, "request authorization returned error with unexpected domain '\(requestAuthError.domain)'")
             print("REQUEST AUTH: error requesting authorization. error is \(requestAuthError.localizedDescription)")
@@ -71,7 +73,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         // Register the listener
-        if let addListenerError = LocationUpdateService().registerListener(self, request: request) {
+        do {
+            try LocationUpdateService().registerListener(self, request: request)
+        } catch let addListenerError as NSError {
             print("LISTENER 1: error in adding the listener. error is \(addListenerError.localizedDescription)")
             return
         }

--- a/ELLocationExample/AppDelegate.swift
+++ b/ELLocationExample/AppDelegate.swift
@@ -26,11 +26,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func requestLocationAuthorization() {
         do {
             try LocationAuthorizationService().requestAuthorization(.WhenInUse)
-        } catch let requestAuthError as NSError {
-            //TODO: Client needs to process error and re-request auth
-            assert(requestAuthError.domain == ELLocationErrorDomain, "request authorization returned error with unexpected domain '\(requestAuthError.domain)'")
-            print("REQUEST AUTH: error requesting authorization. error is \(requestAuthError.localizedDescription)")
-            return
+        } catch {
+            //TODO: Client needs to process error and re-request auth. See code
+            //documentation for information on what errors can be thrown.
+            assert(error is ELLocationError, "request authorization returned error with unexpected error '\(error)'")
+            print("REQUEST AUTH: error requesting authorization, error: \(error).")
         }
 
         startLocationUpdates()
@@ -75,8 +75,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Register the listener
         do {
             try LocationUpdateService().registerListener(self, request: request)
-        } catch let addListenerError as NSError {
-            print("LISTENER 1: error in adding the listener. error is \(addListenerError.localizedDescription)")
+        } catch {
+            print("LISTENER 1: error in adding the listener. error is \(error)")
             return
         }
 

--- a/ELLocationExample/AppDelegate.swift
+++ b/ELLocationExample/AppDelegate.swift
@@ -28,9 +28,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             //TODO: Client needs to process error and re-request auth
             assert(requestAuthError.domain == ELLocationErrorDomain, "request authorization returned error with unexpected domain '\(requestAuthError.domain)'")
             print("REQUEST AUTH: error requesting authorization. error is \(requestAuthError.localizedDescription)")
-        } else {
-            startLocationUpdates()
+            return
         }
+
+        startLocationUpdates()
     }
 
     func applicationWillResignActive(application: UIApplication) {
@@ -72,8 +73,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Register the listener
         if let addListenerError = LocationUpdateService().registerListener(self, request: request) {
             print("LISTENER 1: error in adding the listener. error is \(addListenerError.localizedDescription)")
-        } else {
-            print("LISTENER 1 ADDED")
+            return
         }
+
+        print("LISTENER 1 ADDED")
     }
 }

--- a/ELLocationExample/AppDelegate.swift
+++ b/ELLocationExample/AppDelegate.swift
@@ -18,6 +18,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         
+        requestLocationAuthorization()
+
+        return true
+    }
+
+    private func requestLocationAuthorization() {
         if let requestAuthError = LocationAuthorizationService().requestAuthorization(.WhenInUse) {
             //TODO: Client needs to process error and re-request auth
             assert(requestAuthError.domain == ELLocationErrorDomain, "request authorization returned error with unexpected domain '\(requestAuthError.domain)'")
@@ -25,8 +31,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } else {
             startLocationUpdates()
         }
-        
-        return true
     }
 
     func applicationWillResignActive(application: UIApplication) {
@@ -72,6 +76,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("LISTENER 1 ADDED")
         }
     }
-
 }
-

--- a/ELLocationExample/FirstViewController.swift
+++ b/ELLocationExample/FirstViewController.swift
@@ -33,8 +33,10 @@ class FirstViewController: UIViewController {
                     }
                 }
             }
-            
-            if let requestError = LocationUpdateService().registerListener(listener3, request: request) {
+
+            do {
+                try LocationUpdateService().registerListener(listener3, request: request)
+            } catch let requestError as NSError  {
                 print("LISTENER 3: error in making request. error is \(requestError.localizedDescription)")
                 return
             }
@@ -62,8 +64,10 @@ class FirstViewController: UIViewController {
                     }
                 }
             }
-            
-            if let requestError = LocationUpdateService().registerListener(listener4, request: request) {
+
+            do {
+                try LocationUpdateService().registerListener(listener4, request: request)
+            } catch let requestError as NSError {
                 print("LISTENER 4: error in making request. error is \(requestError.localizedDescription)")
                 return
             }
@@ -93,8 +97,10 @@ class FirstViewController: UIViewController {
                 }
             }
         }
-        
-        if let requestError = LocationUpdateService().registerListener(self, request: request) {
+
+        do {
+            try LocationUpdateService().registerListener(self, request: request)
+        } catch let requestError as NSError {
             print("LISTENER 2: error in making request. error is \(requestError.localizedDescription)")
             return
         }

--- a/ELLocationExample/FirstViewController.swift
+++ b/ELLocationExample/FirstViewController.swift
@@ -36,10 +36,11 @@ class FirstViewController: UIViewController {
             
             if let requestError = LocationUpdateService().registerListener(listener3, request: request) {
                 print("LISTENER 3: error in making request. error is \(requestError.localizedDescription)")
-            } else {
-                print("LISTENER 3 ADDED")
+                return
             }
-            
+
+            print("LISTENER 3 ADDED")
+
             // Schedule removal after some time seconds
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5_000_000_000), dispatch_get_main_queue()) { () -> Void in
                 print("REMOVING LISTENER 3")
@@ -64,10 +65,11 @@ class FirstViewController: UIViewController {
             
             if let requestError = LocationUpdateService().registerListener(listener4, request: request) {
                 print("LISTENER 4: error in making request. error is \(requestError.localizedDescription)")
-            } else {
-                print("LISTENER 4 ADDED")
+                return
             }
-            
+
+            print("LISTENER 4 ADDED")
+
             // Schedule removal after some time seconds
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10_000_000_000), dispatch_get_main_queue()) { () -> Void in
                 print("LETTING LISTENER 4 BE DEALLOCED")
@@ -94,10 +96,11 @@ class FirstViewController: UIViewController {
         
         if let requestError = LocationUpdateService().registerListener(self, request: request) {
             print("LISTENER 2: error in making request. error is \(requestError.localizedDescription)")
-        } else {
-            print("LISTENER 2 ADDED")
+            return
         }
-        
+
+        print("LISTENER 2 ADDED")
+
         // Schedule removal after some time seconds
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 15_000_000_000), dispatch_get_main_queue()) { () -> Void in
             print("REMOVING LISTENER 2")

--- a/ELLocationExample/FirstViewController.swift
+++ b/ELLocationExample/FirstViewController.swift
@@ -36,8 +36,8 @@ class FirstViewController: UIViewController {
 
             do {
                 try LocationUpdateService().registerListener(listener3, request: request)
-            } catch let requestError as NSError  {
-                print("LISTENER 3: error in making request. error is \(requestError.localizedDescription)")
+            } catch  {
+                print("LISTENER 3: error in making request. error is \(error)")
                 return
             }
 
@@ -67,8 +67,8 @@ class FirstViewController: UIViewController {
 
             do {
                 try LocationUpdateService().registerListener(listener4, request: request)
-            } catch let requestError as NSError {
-                print("LISTENER 4: error in making request. error is \(requestError.localizedDescription)")
+            } catch {
+                print("LISTENER 4: error in making request. error is \(error)")
                 return
             }
 
@@ -100,8 +100,8 @@ class FirstViewController: UIViewController {
 
         do {
             try LocationUpdateService().registerListener(self, request: request)
-        } catch let requestError as NSError {
-            print("LISTENER 2: error in making request. error is \(requestError.localizedDescription)")
+        } catch {
+            print("LISTENER 2: error in making request. error is \(error)")
             return
         }
 

--- a/ELLocationExample/FirstViewController.swift
+++ b/ELLocationExample/FirstViewController.swift
@@ -14,9 +14,13 @@ class FirstViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
-        
-        startLocationUpdates()
-        
+
+        startListener2()
+        startListener3()
+        startListener4()
+    }
+
+    private func startListener3() {
         let listener3: NSObject = NSObject()
         
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1_000_000_000), dispatch_get_main_queue()) { () -> Void in
@@ -42,7 +46,9 @@ class FirstViewController: UIViewController {
                 LocationUpdateService().deregisterListener(listener3)
             }
         }
-        
+    }
+
+    private func startListener4() {
         var listener4: NSObject = NSObject()
         
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1_000_000_000), dispatch_get_main_queue()) { () -> Void in
@@ -75,7 +81,7 @@ class FirstViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
 
-    func startLocationUpdates() {
+    private func startListener2() {
         let request = LocationUpdateRequest(accuracy: .Good, updateFrequency: .Continuous) { (success, location, error) -> Void in
             if success {
                 print("LISTENER 2: success!!!!")


### PR DESCRIPTION
#### What does this PR do?

Changes the method signatures that previously returned optional errors so that they throw those errors instead.
#### Any background context you want to provide?

In PR #22, we touched on the idea of using `throws`. This change makes it "easier" to write code with proper error handling, and harder to ignore errors, which I think is a good thing. Plus, it just feels more Swift-y.

My intention is to start a discussion of whether to take this approach and not _necessarily_ to have this PR merged as is, although that would be good too.
#### Where should the reviewer start?

The first three commits (4126499, 066d021, 79d836c) are housekeeping changes that make the switch to throwing easier. The "real" changes are in the final commit (0e66f82).
